### PR TITLE
Performance Improvements

### DIFF
--- a/layoutanalyzer/src/main/java/nl/knaw/huc/di/images/layoutanalyzer/layoutlib/LayoutProc.java
+++ b/layoutanalyzer/src/main/java/nl/knaw/huc/di/images/layoutanalyzer/layoutlib/LayoutProc.java
@@ -43,6 +43,19 @@ public class LayoutProc {
     private static boolean _outputDebug = true;
     private static final int bestBinarizationThreshold = 15;
     private static final int bestBinarizationBlockSize = 51;
+    private static final double SEAM_NO_GO_ENERGY = 1.0e20;
+
+    private static final class TextLineGeometry {
+        private final TextLine textLine;
+        private final List<Point> baselinePoints;
+        private final Rect baselineRect;
+
+        private TextLineGeometry(TextLine textLine, List<Point> baselinePoints) {
+            this.textLine = textLine;
+            this.baselinePoints = baselinePoints;
+            this.baselineRect = getBoundingBox(baselinePoints);
+        }
+    }
 
     public static void setOutputDebug(boolean _outputDebug) {
         LayoutProc._outputDebug = _outputDebug;
@@ -541,6 +554,11 @@ public class LayoutProc {
         return Math.max(interlineDistance, minValue);
     }
 
+    private static double interlineMedianFromGeometry(List<TextLineGeometry> textLineGeometries, double minValue) {
+        double interlineDistance = interlineMedianFromGeometry(textLineGeometries);
+        return Math.max(interlineDistance, minValue);
+    }
+
 
 
     public static double findClosestDistance(List<Point> polygon1, List<Point> polygon2) {
@@ -604,6 +622,32 @@ public class LayoutProc {
             allPoints.removeAll(points);
             double distance = findClosestDistance(allPoints, points);
             distances.add(distance);
+        }
+        Statistics statistics = new Statistics(distances);
+        return statistics.median();
+    }
+
+    private static double interlineMedianFromGeometry(List<TextLineGeometry> textLineGeometries) {
+        if (textLineGeometries.size() < 2) {
+            return 0;
+        }
+
+        ArrayList<Double> distances = new ArrayList<>(textLineGeometries.size());
+        for (TextLineGeometry textLineGeometry : textLineGeometries) {
+            double closestDistance = Double.MAX_VALUE;
+            for (TextLineGeometry otherLineGeometry : textLineGeometries) {
+                if (textLineGeometry == otherLineGeometry) {
+                    continue;
+                }
+                closestDistance = Math.min(closestDistance,
+                        findClosestDistance(otherLineGeometry.baselinePoints, textLineGeometry.baselinePoints));
+            }
+            if (closestDistance != Double.MAX_VALUE) {
+                distances.add(closestDistance);
+            }
+        }
+        if (distances.isEmpty()) {
+            return 0;
         }
         Statistics statistics = new Statistics(distances);
         return statistics.median();
@@ -1789,12 +1833,48 @@ public class LayoutProc {
         return closest;
     }
 
+    private static TextLineGeometry closestLineAbove(TextLineGeometry current, List<TextLineGeometry> textLines) {
+        Rect currentRect = current.baselineRect;
+        TextLineGeometry closest = null;
+        int closestDistance = Integer.MAX_VALUE;
+        for (TextLineGeometry textLine : textLines) {
+            Rect otherRect = textLine.baselineRect;
+            int distance = currentRect.y - otherRect.y;
+            if (otherRect.x + otherRect.width > currentRect.x
+                    && otherRect.x < currentRect.x + currentRect.width
+                    && otherRect.y < currentRect.y
+                    && distance < closestDistance) {
+                closest = textLine;
+                closestDistance = distance;
+            }
+        }
+        return closest;
+    }
+
     public static synchronized TextLine closestLineBelow(TextLine current, List<TextLine> textLines) {
         Rect currentRect = getBoundingBoxBaseLine(current);
         TextLine closest = null;
         int closestDistance = Integer.MAX_VALUE;
         for (TextLine textLine : textLines) {
             Rect otherRect = getBoundingBoxBaseLine(textLine);
+            int distance = otherRect.y - currentRect.y;
+            if (otherRect.x + otherRect.width > currentRect.x
+                    && otherRect.x < currentRect.x + currentRect.width
+                    && otherRect.y > currentRect.y
+                    && distance < closestDistance) {
+                closest = textLine;
+                closestDistance = distance;
+            }
+        }
+        return closest;
+    }
+
+    private static TextLineGeometry closestLineBelow(TextLineGeometry current, List<TextLineGeometry> textLines) {
+        Rect currentRect = current.baselineRect;
+        TextLineGeometry closest = null;
+        int closestDistance = Integer.MAX_VALUE;
+        for (TextLineGeometry textLine : textLines) {
+            Rect otherRect = textLine.baselineRect;
             int distance = otherRect.y - currentRect.y;
             if (otherRect.x + otherRect.width > currentRect.x
                     && otherRect.x < currentRect.x + currentRect.width
@@ -1855,7 +1935,7 @@ public class LayoutProc {
         grayImageInverted = OpenCVWrapper.release(grayImageInverted);
 
         Mat combined = OpenCVWrapper.newMat();
-        OpenCVWrapper.addWeighted(sobel1, sobel2, combined, CV_64F);
+        OpenCVWrapper.addWeighted(sobel1, sobel2, combined, destination.type());
         if (combined.size().width == 0 || combined.size().height == 0) {
             LOG.error("broken combined");
             throw new RuntimeException("broken combined");
@@ -1865,7 +1945,7 @@ public class LayoutProc {
         Mat binary = OpenCVWrapper.newMat(grayImage.size(), CV_8U);
         OpenCVWrapper.adaptiveThreshold(grayImage, binary, 21);
 
-        OpenCVWrapper.addWeighted(combined, binary, combined, CV_64F);
+        OpenCVWrapper.addWeighted(combined, binary, combined, destination.type());
         binary = OpenCVWrapper.release(binary);
 
         OpenCVWrapper.GaussianBlur(combined, destination);
@@ -1875,35 +1955,48 @@ public class LayoutProc {
     private static void drawBaselines(String identifier, List<TextLine> textlines, Mat image, int thickness) {
         for (TextLine textLine : textlines) {
             ArrayList<Point> points = StringConverter.stringToPoint(textLine.getBaseline().getPoints());
-            Point lastPoint = null;
-            Scalar scalar =null;
-            if (image.type() == CV_8UC1) {
-                scalar = new Scalar(255);
-            }else if (image.type() == CV_8UC3) {
-                scalar = new Scalar(255, 255, 255);
-            }else if (image.type()== CV_64F){
-                scalar = new Scalar(255);
-            }else {
-                throw new RuntimeException("Unsupported image type");
+            drawBaseline(identifier, points, image, thickness);
+        }
+    }
+
+    private static void drawBaselinesFromGeometry(String identifier, List<TextLineGeometry> textlines, Mat image, int thickness) {
+        for (TextLineGeometry textLine : textlines) {
+            drawBaseline(identifier, textLine.baselinePoints, image, thickness);
+        }
+    }
+
+    private static void drawBaseline(String identifier, List<Point> points, Mat image, int thickness) {
+        Point lastPoint = null;
+        Scalar scalar;
+        if (image.type() == CV_8UC1) {
+            scalar = new Scalar(255);
+        } else if (image.type() == CV_8UC3) {
+            scalar = new Scalar(255, 255, 255);
+        } else if (image.type() == CV_32F) {
+            scalar = new Scalar(255);
+        } else if (image.type() == CV_64F) {
+            scalar = new Scalar(255);
+        } else {
+            throw new RuntimeException("Unsupported image type");
+        }
+        for (Point point : points) {
+            Point clippedPoint = new Point(point.x, point.y);
+            if (clippedPoint.x < 0) {
+                clippedPoint.x = 0;
             }
-            for (Point point : points) {
-                if (point.x < 0) {
-                    point.x = 0;
-                }
-                if (point.x >= image.width()) {
-                    point.x = image.width() - 1;
-                }
-                if (point.y < 0) {
-                    point.y = 0;
-                }
-                if (point.y >= image.height()) {
-                    point.y = image.height() - 1;
-                }
-                if (lastPoint != null) {
-                    OpenCVWrapper.line(identifier, image, lastPoint, point, scalar, thickness);
-                }
-                lastPoint = point;
+            if (clippedPoint.x >= image.width()) {
+                clippedPoint.x = image.width() - 1;
             }
+            if (clippedPoint.y < 0) {
+                clippedPoint.y = 0;
+            }
+            if (clippedPoint.y >= image.height()) {
+                clippedPoint.y = image.height() - 1;
+            }
+            if (lastPoint != null) {
+                OpenCVWrapper.line(identifier, image, lastPoint, clippedPoint, scalar, thickness);
+            }
+            lastPoint = clippedPoint;
         }
     }
 
@@ -2291,16 +2384,16 @@ public class LayoutProc {
                                                                 int thickness, int minimumBaselineThickness, boolean ignoreBroken) {
         Mat grayImage = OpenCVWrapper.newMat(image.size(), CV_8UC1);
         OpenCVWrapper.cvtColor(image, grayImage);
-        Mat energyImage = new Mat(grayImage.size(), CV_64F);
+        Mat energyImage = new Mat(grayImage.size(), CV_32F);
 
         energyImage(grayImage, energyImage);
         if (energyImage.size().width == 0 || energyImage.size().height == 0) {
             LOG.error("broken energyImage");
             throw new RuntimeException("broken energyImage");
         }
-        if (energyImage.type() != CV_64F) {
-            LOG.error("energyImage type is not CV_64F, but: " + energyImage.type());
-            throw new RuntimeException("energyImage type is not CV_64F, but: " + energyImage.type());
+        if (energyImage.type() != CV_32F) {
+            LOG.error("energyImage type is not CV_32F, but: " + energyImage.type());
+            throw new RuntimeException("energyImage type is not CV_32F, but: " + energyImage.type());
         }
         List<TextLine> allLines = new ArrayList<>();
         for (TextRegion textRegion : page.getPage().getTextRegions()) {
@@ -2317,13 +2410,24 @@ public class LayoutProc {
         }
         allLines.removeAll(linesToRemove);
 
+        List<TextLineGeometry> allLineGeometries = new ArrayList<>();
+        Map<TextLine, TextLineGeometry> geometryByTextLine = new IdentityHashMap<>();
+        for (TextLine textLine : allLines) {
+            List<Point> baselinePoints = StringConverter.stringToPoint(textLine.getBaseline().getPoints());
+            if (baselinePoints.size() <= 1) {
+                continue;
+            }
+            TextLineGeometry textLineGeometry = new TextLineGeometry(textLine, baselinePoints);
+            allLineGeometries.add(textLineGeometry);
+            geometryByTextLine.put(textLine, textLineGeometry);
+        }
 
-        Mat baselineImage = new Mat(energyImage.size(), CV_64F);
-        energyImage.convertTo(baselineImage, CV_64F);
-        drawBaselines(identifier, allLines, baselineImage, thickness);
+        Mat baselineImage = new Mat(energyImage.size(), energyImage.type());
+        energyImage.copyTo(baselineImage);
+        drawBaselinesFromGeometry(identifier, allLineGeometries, baselineImage, thickness);
 
         int counter = 0;
-        double interlineDistance = LayoutProc.interlineMedian(allLines, minimumInterlineDistance);//94;
+        double interlineDistance = LayoutProc.interlineMedianFromGeometry(allLineGeometries, minimumInterlineDistance);//94;
         LOG.info(identifier + " interline distance: " + interlineDistance);
 
         Stopwatch stopwatch = Stopwatch.createStarted();
@@ -2339,8 +2443,12 @@ public class LayoutProc {
                         throw new RuntimeException("Textline has no baseline: " + textLine.getId());
                     }
                 }
-                counter = recalculateTextLine(identifier, scaleDownFactor, textLine, interlineDistance, stopwatch,
-                        allLines, energyImage, baselineImage, counter, minimumBaselineThickness);
+                TextLineGeometry textLineGeometry = geometryByTextLine.get(textLine);
+                if (textLineGeometry == null) {
+                    continue;
+                }
+                counter = recalculateTextLine(identifier, scaleDownFactor, textLineGeometry, interlineDistance, stopwatch,
+                        allLineGeometries, energyImage, baselineImage, counter, minimumBaselineThickness);
             }
         }
         grayImage = OpenCVWrapper.release(grayImage);
@@ -2352,9 +2460,10 @@ public class LayoutProc {
         }
     }
 
-    private static int recalculateTextLine(String identifier, double scaleDownFactor, TextLine textLine,
-                                           double interlineDistance, Stopwatch stopwatch, List<TextLine> allLines,
+    private static int recalculateTextLine(String identifier, double scaleDownFactor, TextLineGeometry textLineGeometry,
+                                           double interlineDistance, Stopwatch stopwatch, List<TextLineGeometry> allLines,
                                            Mat energyImage, Mat baselineImage, int counter, int minimumBaselineThickness) {
+        TextLine textLine = textLineGeometry.textLine;
         double xHeightBasedOnInterline = interlineDistance / 3;
         if (xHeightBasedOnInterline < (MINIMUM_XHEIGHT)) {
             xHeightBasedOnInterline = (MINIMUM_XHEIGHT);
@@ -2366,13 +2475,13 @@ public class LayoutProc {
         }
         long startTime = stopwatch.elapsed(TimeUnit.MILLISECONDS);
         int xMargin = (int) xHeightBasedOnInterline;
-        List<Point> baseLinePoints = StringConverter.stringToPoint(textLine.getBaseline().getPoints());
+        List<Point> baseLinePoints = textLineGeometry.baselinePoints;
         if (baseLinePoints.size() <= 1) {
             // no base line, use existing textline Coords
             return counter;
         }
-        Rect baselineRect = LayoutProc.getBoundingBox(baseLinePoints);
-        TextLine closestAbove = LayoutProc.closestLineAbove(textLine, allLines);
+        Rect baselineRect = textLineGeometry.baselineRect;
+        TextLineGeometry closestAbove = LayoutProc.closestLineAbove(textLineGeometry, allLines);
         double localInterlineDistance = getLocalInterlineDistance(interlineDistance, baselineRect, null);
 
         double yStartTop = getYStartTop(baseLinePoints, localInterlineDistance);
@@ -2390,8 +2499,9 @@ public class LayoutProc {
             return counter;
         }
         Mat baselineImageSubmat = baselineImage.submat(roi);
-
-        Mat averageMat = new Mat(roi.height, roi.width, CV_64F, Core.mean(energyImage.submat(roi)));
+        Mat energyImageSubmat = energyImage.submat(roi);
+        Mat averageMat = new Mat(roi.height, roi.width, energyImage.type(), Core.mean(energyImageSubmat));
+        energyImageSubmat = OpenCVWrapper.release(energyImageSubmat);
         if (!baselineImageSubmat.size().equals(averageMat.size()) || baselineImageSubmat.type() != averageMat.type()) {
             LOG.error("Matrix dimensions or types are not compatible for subtraction. baselineImageSubmat.size(): " + baselineImageSubmat.size() + " averageMat.size(): " + averageMat.size() + " baselineImageSubmat.type(): " + baselineImageSubmat.type() + " averageMat.type(): " + averageMat.type());
             throw new RuntimeException("Matrix dimensions or types are not compatible for subtraction.");
@@ -2413,6 +2523,7 @@ public class LayoutProc {
             throw cvException;
         }
 //        baselineImageSubmat = OpenCVWrapper.release(baselineImageSubmat);
+        baselineImageSubmat = OpenCVWrapper.release(baselineImageSubmat);
         averageMat = OpenCVWrapper.release(averageMat);
 
         int newWidth = (int) Math.ceil(clonedMat.width() / scaleDownFactor);
@@ -2424,7 +2535,7 @@ public class LayoutProc {
 
         // no-go area above the baseline closest above this baseline
         if (closestAbove != null) {
-            for (Point point : expandPointList(StringConverter.stringToPoint(closestAbove.getBaseline().getPoints()))) {
+            for (Point point : expandPointList(closestAbove.baselinePoints)) {
                 if (point.x - roi.x < 0 || point.x - roi.x >= clonedMat.width()) {
                     continue;
                 }
@@ -2434,7 +2545,7 @@ public class LayoutProc {
                             clonedMat,
                             new Point(point.x - roi.x, 0),
                             new Point(point.x - roi.x, yTarget),
-                            new Scalar(Float.MAX_VALUE),
+                            new Scalar(SEAM_NO_GO_ENERGY),
                             1);
                 }
             }
@@ -2447,7 +2558,7 @@ public class LayoutProc {
                 Imgproc.line(clonedMat,
                         new Point(point.x - roi.x, point.y - roi.y),
                         new Point(point.x - roi.x, lastPoint.y - roi.y),
-                        new Scalar(Float.MAX_VALUE),
+                        new Scalar(SEAM_NO_GO_ENERGY),
                         baselineThickness);
             }
             lastPoint = point;
@@ -2458,14 +2569,14 @@ public class LayoutProc {
             Imgproc.line(clonedMat,
                     new Point(point.x - roi.x, point.y - roi.y),
                     new Point(point.x - roi.x, clonedMat.height()),
-                    new Scalar(Float.MAX_VALUE),
+                    new Scalar(SEAM_NO_GO_ENERGY),
                     1);
         }
 
 
         LayoutProc.calcSeamImage(clonedMat, newSize, seamImageTop);
-        if (seamImageTop.type()!= CV_64F){
-            LOG.error("seamImageTop.type()!= CV_64F");
+        if (seamImageTop.type()!= energyImage.type()){
+            LOG.error("seamImageTop.type()!= energyImage.type()");
         }
         clonedMat = OpenCVWrapper.release(clonedMat);
         if (seamImageTop.height() <= 2) {
@@ -2512,16 +2623,16 @@ public class LayoutProc {
         }
         roi = new Rect(xStop, (int) yStartTop, xStart - xStop, (int) (yStartBottom - yStartTop));
         Mat tmpSubmat2 = energyImage.submat(roi);
-        Mat average2 = new Mat(roi.size(), CV_8UC1, Core.mean(tmpSubmat2));
-//        tmpSubmat2 = OpenCVWrapper.release(tmpSubmat2);
+        Mat average2 = new Mat(roi.size(), energyImage.type(), Core.mean(tmpSubmat2));
+        tmpSubmat2 = OpenCVWrapper.release(tmpSubmat2);
 
         baselineImageSubmat = baselineImage.submat(roi);
-        Mat cloned2 = new Mat(roi.size(), CV_64F);
-        Core.subtract(baselineImageSubmat, average2, cloned2, Mat.ones(baselineImageSubmat.size(), CV_8UC1), CV_64F);
+        Mat cloned2 = new Mat(roi.size(), energyImage.type());
+        Core.subtract(baselineImageSubmat, average2, cloned2);
 //        Mat cloned2 = baselineImageSubmat.clone();
 
         average2 = OpenCVWrapper.release(average2);
-//        baselineImageSubmat = OpenCVWrapper.release(baselineImageSubmat);
+        baselineImageSubmat = OpenCVWrapper.release(baselineImageSubmat);
 
         List<Point> localPoints = new ArrayList<>();
         for (Point point : baseLinePoints) {
@@ -2547,7 +2658,7 @@ public class LayoutProc {
             lastBaseLinePoint = point;
         }
 
-        TextLine closestBelow = LayoutProc.closestLineBelow(textLine, allLines);
+        TextLineGeometry closestBelow = LayoutProc.closestLineBelow(textLineGeometry, allLines);
 
         int newWidthBottom = (int) Math.ceil(cloned2.width() / scaleDownFactor);
         int newHeightBottom = (int) Math.ceil(cloned2.height() / scaleDownFactor);
@@ -2561,7 +2672,7 @@ public class LayoutProc {
                 Imgproc.line(cloned2,
                         new Point(point.x - roi.x, point.y - roi.y),
                         new Point(point.x - roi.x, lastBaseLinePoint.y - roi.y),
-                        new Scalar(Float.MAX_VALUE),
+                        new Scalar(SEAM_NO_GO_ENERGY),
                         1);
             }
             lastBaseLinePoint = point;
@@ -2572,14 +2683,14 @@ public class LayoutProc {
             Imgproc.line(cloned2,
                     new Point(point.x - roi.x, point.y - roi.y),
                     new Point(point.x - roi.x, 0),
-                    new Scalar(Float.MAX_VALUE),
+                    new Scalar(SEAM_NO_GO_ENERGY),
                     1);
         }
 
 //        no-go area of baseline below this baseline
 
         if (closestBelow != null) {
-            for (Point point : expandPointList(StringConverter.stringToPoint(closestBelow.getBaseline().getPoints()))) {
+            for (Point point : expandPointList(closestBelow.baselinePoints)) {
                 int yTarget = (int) point.y - roi.y;
                 if (yTarget > 0
                         && yTarget < cloned2.height()
@@ -2589,7 +2700,7 @@ public class LayoutProc {
                             cloned2,
                             new Point(point.x - roi.x, yTarget),
                             new Point(point.x - roi.x, cloned2.height()),
-                            new Scalar(Float.MAX_VALUE),
+                            new Scalar(SEAM_NO_GO_ENERGY),
                             baselineThickness);
                 }
             }
@@ -3619,13 +3730,19 @@ Gets a text line from an image based on the baseline and contours. Text line is 
         if (mat.channels()>1){
             throw new RuntimeException("Mat has more than 1 channel, data is single channel");
         }
-        if (mat.type() != CV_64F) {
-            throw new RuntimeException("Mat type is not CV_64F but of type: " + mat.type());
+        if (mat.type() != CV_64F && mat.type() != CV_32F) {
+            throw new RuntimeException("Mat type is not CV_64F/CV_32F but of type: " + mat.type());
         }
         if (i>=0 && i<mat.height() && j>=0 && j<mat.width()){
-            double[] dataDouble = new double[1];
-            dataDouble[0] = data;
-            mat.put(i, j, dataDouble);
+            if (mat.type() == CV_64F) {
+                double[] dataDouble = new double[1];
+                dataDouble[0] = data;
+                mat.put(i, j, dataDouble);
+            } else {
+                float[] dataFloat = new float[1];
+                dataFloat[0] = (float) data;
+                mat.put(i, j, dataFloat);
+            }
         }else{
             LOG.error("Trying to put data outside of mat: " + i + " " + j);
             throw new RuntimeException("writing outside bounds");
@@ -3665,11 +3782,16 @@ Gets a text line from an image based on the baseline and contours. Text line is 
         if (mat.channels()>1){
             throw new RuntimeException("Mat has more than 1 channel, data is single channel");
         }
-        if (mat.type() != CV_64F){
-            throw new RuntimeException("Mat type is not CV_64F but of type: " + mat.type());
+        if (mat.type() != CV_64F && mat.type() != CV_32F){
+            throw new RuntimeException("Mat type is not CV_64F/CV_32F but of type: " + mat.type());
         }
         if (i>=0 && i<mat.height() && j>=0 && j<mat.width()){
-            final double[] data = new double[1];
+            if (mat.type() == CV_64F) {
+                final double[] data = new double[1];
+                mat.get(i, j, data);
+                return data[0];
+            }
+            final float[] data = new float[1];
             mat.get(i, j, data);
             return data[0];
         }else{

--- a/layoutanalyzer/src/main/java/nl/knaw/huc/di/images/layoutanalyzer/layoutlib/LayoutProc.java
+++ b/layoutanalyzer/src/main/java/nl/knaw/huc/di/images/layoutanalyzer/layoutlib/LayoutProc.java
@@ -1717,8 +1717,80 @@ public class LayoutProc {
         Mat seamImageResized = OpenCVWrapper.newMat();
         Imgproc.resize(energyMat, seamImageResized, newSize, 0, 0, INTER_NEAREST);
 
-        for (int j = 0; j < seamImageResized.width(); j++) {
-            for (int i = 0; i < seamImageResized.height(); i++) {
+        int height = seamImageResized.height();
+        int width = seamImageResized.width();
+        int type = seamImageResized.type();
+
+        if (type == CV_32F) {
+            calcSeamImageFloat(seamImageResized, height, width);
+        } else if (type == CV_64F) {
+            calcSeamImageDouble(seamImageResized, height, width);
+        } else {
+            // Per-pixel fallback path for any unexpected types. Kept for safety; the
+            // production callers always pass CV_32F.
+            calcSeamImageGeneric(seamImageResized, height, width);
+        }
+
+        Imgproc.resize(seamImageResized, destination, new Size(energyMat.width(), energyMat.height()));
+        seamImageResized = OpenCVWrapper.release(seamImageResized); // Release seamImage
+    }
+
+    private static void calcSeamImageFloat(Mat seamImageResized, int height, int width) {
+        // Bulk-read the entire resized seam image into a single float[] and run the
+        // column-major DP in pure Java. Replaces a nested per-pixel getSafeDouble /
+        // safePut pair (each allocating a fresh float[1]) with two JNI transitions.
+        float[] data = new float[height * width];
+        seamImageResized.get(0, 0, data);
+        for (int j = 0; j < width; j++) {
+            if (j == 0) {
+                // First column has no predecessor; lowest is 0 by definition.
+                for (int i = 0; i < height; i++) {
+                    // data[i*width + j] += 0; no-op.
+                }
+                continue;
+            }
+            int prevCol = j - 1;
+            for (int i = 0; i < height; i++) {
+                int yUp = i > 0 ? i - 1 : 0;
+                int yDn = i + 1 < height ? i + 1 : height - 1;
+                float a = data[yUp * width + prevCol];
+                float b = data[i * width + prevCol];
+                float c = data[yDn * width + prevCol];
+                float lowest = a < b ? a : b;
+                if (c < lowest) lowest = c;
+                int idx = i * width + j;
+                data[idx] = lowest + data[idx];
+            }
+        }
+        seamImageResized.put(0, 0, data);
+    }
+
+    private static void calcSeamImageDouble(Mat seamImageResized, int height, int width) {
+        double[] data = new double[height * width];
+        seamImageResized.get(0, 0, data);
+        for (int j = 0; j < width; j++) {
+            if (j == 0) {
+                continue;
+            }
+            int prevCol = j - 1;
+            for (int i = 0; i < height; i++) {
+                int yUp = i > 0 ? i - 1 : 0;
+                int yDn = i + 1 < height ? i + 1 : height - 1;
+                double a = data[yUp * width + prevCol];
+                double b = data[i * width + prevCol];
+                double c = data[yDn * width + prevCol];
+                double lowest = a < b ? a : b;
+                if (c < lowest) lowest = c;
+                int idx = i * width + j;
+                data[idx] = lowest + data[idx];
+            }
+        }
+        seamImageResized.put(0, 0, data);
+    }
+
+    private static void calcSeamImageGeneric(Mat seamImageResized, int height, int width) {
+        for (int j = 0; j < width; j++) {
+            for (int i = 0; i < height; i++) {
                 double lowest = Double.MAX_VALUE;
                 for (int m = -1; m <= 1; m++) {
                     int y = i + m;
@@ -1726,35 +1798,26 @@ public class LayoutProc {
                     if (y < 0) {
                         y = 0;
                     }
-                    if (y >= seamImageResized.height()) {
-                        y = seamImageResized.height() - 1;
+                    if (y >= height) {
+                        y = height - 1;
                     }
-
                     if (x < 0) {
                         lowest = 0;
                     } else {
-                        double value = getSafeDouble(seamImageResized,y, x);
+                        double value = getSafeDouble(seamImageResized, y, x);
                         if (value < lowest || lowest == Double.MAX_VALUE) {
                             lowest = value;
                         }
                     }
                 }
                 if (lowest == Double.MAX_VALUE) {
-                    LOG.error("Lowest is still Double.MAX_VALUE. i = " + i + " j = " + j + " seamImage.height() = " + seamImageResized.height() + " seamImage.width() = " + seamImageResized.width());
+                    LOG.error("Lowest is still Double.MAX_VALUE. i = " + i + " j = " + j + " seamImage.height() = " + height + " seamImage.width() = " + width);
                     lowest = 0;
-                }
-                if (i >= seamImageResized.height()){
-                    throw new RuntimeException("i: " + i + " j: " + j);
-                }
-                if (j >= seamImageResized.width()){
-                    throw new RuntimeException("i: " + i + " j: " + j);
                 }
                 double putter = lowest + getSafeDouble(seamImageResized, i, j);
                 safePut(seamImageResized, i, j, putter);
             }
         }
-        Imgproc.resize(seamImageResized, destination, new Size(energyMat.width(), energyMat.height()));
-        seamImageResized = OpenCVWrapper.release(seamImageResized); // Release seamImage
     }
 
     public static double getMeanAngle(List<Double> anglesDeg) {
@@ -3216,15 +3279,11 @@ Gets a text line from an image based on the baseline and contours. Text line is 
 
             Mat grayImage = OpenCVWrapper.newMat(deskewedSubmat.size(), CV_8UC1);
             OpenCVWrapper.cvtColor(deskewedSubmat, grayImage);
-            Mat grayImageInverted = OpenCVWrapper.newMat(grayImage.size(), grayImage.type());
-            OpenCVWrapper.bitwise_not(grayImage, grayImageInverted);
-            grayImage = OpenCVWrapper.release(grayImage);
-            Scalar meanGray = Core.mean(grayImageInverted);
-            Mat average = OpenCVWrapper.newMat(grayImageInverted.size(), CV_8UC1, meanGray);
+            OpenCVWrapper.bitwise_not(grayImage, grayImage);
+            Scalar meanGray = Core.mean(grayImage);
             Mat tmpGrayBackgroundSubtracted = OpenCVWrapper.newMat();
-            Core.subtract(grayImageInverted, average, tmpGrayBackgroundSubtracted);
-            average = OpenCVWrapper.release(average);
-            grayImageInverted = OpenCVWrapper.release(grayImageInverted);
+            Core.subtract(grayImage, meanGray, tmpGrayBackgroundSubtracted);
+            grayImage = OpenCVWrapper.release(grayImage);
 
             Mat maskedBinary = new Mat(mask.rows(), mask.cols(), mask.type());
             tmpGrayBackgroundSubtracted.copyTo(maskedBinary, mask);
@@ -3264,37 +3323,38 @@ Gets a text line from an image based on the baseline and contours. Text line is 
     }
 
     private static void getMaskedOutput(String identifier, Integer xHeight, boolean includeMask, Mat deskewedSubmat, Mat mask, int medianY, Mat destination) {
-        List<Mat> splittedImage = new ArrayList<>();
-        Core.split(deskewedSubmat, splittedImage);
+        if (mask.height() != deskewedSubmat.height()) {
+            LOG.error("mask.height()!= deskewedSubmat.height()");
+        }
+        if (mask.width() != deskewedSubmat.width()) {
+            LOG.error("mask.width()!= deskewedSubmat.width()");
+        }
+        if (mask.channels() != 1) {
+            new Exception(" mask.channels() != 1").printStackTrace();
+        }
+        if (mask.type() != CV_8UC1) {
+            new Exception(" mask.type() != CV_8UC1").printStackTrace();
+        }
+
+        Mat finalOutput = null;
         Mat finalFinalOutputTmp = null;
-        List<Mat> toMerge = null;
-
+        boolean ownsFinalOutput = false;
+        MatOfInt fromTo = null;
         try {
-            if (mask.height()!= deskewedSubmat.height()){
-                LOG.error("mask.height()!= deskewedSubmat.height()");
-            }
-            if (mask.width()!= deskewedSubmat.width()){
-                LOG.error("mask.width()!= deskewedSubmat.width()");
+            if (includeMask) {
+                // Build the BGRA result in a single mixChannels pass: BGR comes from
+                // deskewedSubmat (channels 0-2), alpha from mask (channel 3 of the
+                // concatenated input list). This replaces a Core.split / Core.merge
+                // round-trip that allocated 3 single-channel scratch Mats per line.
+                finalOutput = new Mat(deskewedSubmat.size(), CV_8UC4);
+                ownsFinalOutput = true;
+                fromTo = new MatOfInt(0, 0, 1, 1, 2, 2, 3, 3);
+                Core.mixChannels(Arrays.asList(deskewedSubmat, mask), Arrays.asList(finalOutput), fromTo);
+            } else {
+                // No alpha needed: the deskewed BGR Mat is the final output already.
+                finalOutput = deskewedSubmat;
             }
 
-            if (includeMask) {
-                toMerge = Arrays.asList(splittedImage.get(0), splittedImage.get(1), splittedImage.get(2), mask);//, mask);
-            } else {
-                toMerge = Arrays.asList(splittedImage.get(0), splittedImage.get(1), splittedImage.get(2));//, mask);
-            }
-            if (mask.channels() != 1) {
-                new Exception(" mask.channels() != 1").printStackTrace();
-            }
-            if (mask.type() != CV_8UC1) {
-                new Exception(" mask.type() != CV_8UC1").printStackTrace();
-            }
-            Mat finalOutput=null;
-            if (toMerge.size() == 3) {
-                finalOutput = new Mat(toMerge.get(0).size(), CV_8UC3);
-            }else{
-                finalOutput = new Mat(toMerge.get(0).size(), CV_8UC4);
-            }
-            OpenCVWrapper.merge(toMerge, finalOutput);
             int rowStart = medianY - 2 * xHeight;
             if (rowStart < 0) {
                 rowStart = 0;
@@ -3313,16 +3373,16 @@ Gets a text line from an image based on the baseline and contours. Text line is 
 
         } catch (Exception ex) {
             ex.printStackTrace();
-            LOG.error(identifier + ": toMerge.size() " + toMerge.size());
             LOG.error(identifier + ": deskewSubmat.size() " + deskewedSubmat.size());
             LOG.error(identifier + ": mask.size() " + mask.size());
             new Exception("here").printStackTrace();
-        }finally {
+        } finally {
             finalFinalOutputTmp = OpenCVWrapper.release(finalFinalOutputTmp);
-            for (Mat mat : splittedImage) {
-                if (mat != null) {
-                    OpenCVWrapper.release(mat);
-                }
+            if (ownsFinalOutput && finalOutput != null) {
+                OpenCVWrapper.release(finalOutput);
+            }
+            if (fromTo != null) {
+                OpenCVWrapper.release(fromTo);
             }
         }
     }

--- a/layoutanalyzer/src/main/java/nl/knaw/huc/di/images/layoutanalyzer/layoutlib/LayoutProc.java
+++ b/layoutanalyzer/src/main/java/nl/knaw/huc/di/images/layoutanalyzer/layoutlib/LayoutProc.java
@@ -3642,23 +3642,12 @@ Gets a text line from an image based on the baseline and contours. Text line is 
 
                         final double baselineLength = StringConverter.calculateBaselineLength(baselinePoints);
 
+                        List<String> words = splitWordsOnSpace(text);
                         int numchars = 0;
-                        int spaces = 0;
-                        String[] splitted = text.split(" ");
-                        boolean skipInitialSpace = true;
-                        for (final String wordString : splitted) {
-                            if (Strings.isNullOrEmpty(wordString)) {
-                                continue;
-                            }
+                        for (final String wordString : words) {
                             numchars += wordString.length();
-                            if (skipInitialSpace) {
-                                skipInitialSpace = false;
-                                continue;
-                            } else {
-                                // add a space
-                                spaces++;
-                            }
                         }
+                        int spaces = Math.max(0, words.size() - 1);
                         double charWidth = baselineLength / (numchars + spaces);
                         if (charWidth < 2) {
                             textLinesToRemove.add(textLine);
@@ -3670,26 +3659,30 @@ Gets a text line from an image based on the baseline and contours. Text line is 
                         // FIXME see TI-541
                         final int magicValueForYHigherThanWord = 35;
                         final int magicValueForYLowerThanWord = 10;
-                        StringBuilder currentSentence = new StringBuilder();
-                        List<Point> sentenceBaselinePoints = new ArrayList<>();
-                        for (final String wordString : splitted) {
-                            if (Strings.isNullOrEmpty(wordString)) {
-                                continue;
-                            }
+                        int currentSentenceLength = 0;
+                        double sentenceBaselineLength = 0;
+                        Point lastSentenceBaselinePoint = null;
+                        for (final String wordString : words) {
                             Word word = new Word();
                             word.setTextEquiv(new TextEquiv(null, UNICODE_TO_ASCII_TRANSLITIRATOR.toAscii(wordString), wordString));
                             List<Point> wordBaselinePoints = new ArrayList<>();
 
                             double wordLength = wordString.length() * charWidth;
                             Point nextBaselinePoint;
+                            Point previousWordBaselinePoint = null;
+                            double wordBaselineLength = 0;
                             // FIXME Something goes wrong when wordBaseLinePoints is larger than wordLength
 //                            0.1 is added to avoid rounding errors
-                            while (StringConverter.calculateBaselineLength(wordBaselinePoints) + 0.1 < wordLength) {
+                            while (wordBaselineLength + 0.1 < wordLength) {
                                 if (nextBaseLinePointIndex >= baselinePoints.size()) {
                                     break;
                                 }
                                 nextBaselinePoint = baselinePoints.get(nextBaseLinePointIndex);
+                                if (previousWordBaselinePoint != null) {
+                                    wordBaselineLength += StringConverter.distance(previousWordBaselinePoint, nextBaselinePoint);
+                                }
                                 wordBaselinePoints.add(nextBaselinePoint);
+                                previousWordBaselinePoint = nextBaselinePoint;
                                 nextBaseLinePointIndex++;
                             }
 
@@ -3699,12 +3692,21 @@ Gets a text line from an image based on the baseline and contours. Text line is 
                                     magicValueForYLowerThanWord, wordString, wordBaselinePoints);
                             word.setCoords(wordCoords);
                             textLine.getWords().add(word);
-                            sentenceBaselinePoints.addAll(wordBaselinePoints);
-                            currentSentence.append(wordString);
-                            while (nextBaseLinePointIndex + 1 < baselinePoints.size() && StringConverter.calculateBaselineLength(sentenceBaselinePoints) < charWidth * (currentSentence.length()+1)) {
-                                sentenceBaselinePoints.add(baselinePoints.get(++nextBaseLinePointIndex));
+                            for (Point wordBaselinePoint : wordBaselinePoints) {
+                                if (lastSentenceBaselinePoint != null) {
+                                    sentenceBaselineLength += StringConverter.distance(lastSentenceBaselinePoint, wordBaselinePoint);
+                                }
+                                lastSentenceBaselinePoint = wordBaselinePoint;
                             }
-                            currentSentence.append(" ");
+                            currentSentenceLength += wordString.length();
+                            while (nextBaseLinePointIndex + 1 < baselinePoints.size() && sentenceBaselineLength < charWidth * (currentSentenceLength + 1)) {
+                                Point sentenceBaselinePoint = baselinePoints.get(++nextBaseLinePointIndex);
+                                if (lastSentenceBaselinePoint != null) {
+                                    sentenceBaselineLength += StringConverter.distance(lastSentenceBaselinePoint, sentenceBaselinePoint);
+                                }
+                                lastSentenceBaselinePoint = sentenceBaselinePoint;
+                            }
+                            currentSentenceLength++;
                         }
                     }
                 }
@@ -3725,6 +3727,27 @@ Gets a text line from an image based on the baseline and contours. Text line is 
         metadataItem.setValue("loghi-htr-tooling");
 
         page.getMetadata().getMetadataItems().add(metadataItem);
+    }
+
+    private static List<String> splitWordsOnSpace(String text) {
+        List<String> words = new ArrayList<>();
+        int length = text.length();
+        int start = 0;
+        while (start < length) {
+            while (start < length && text.charAt(start) == ' ') {
+                start++;
+            }
+            if (start >= length) {
+                break;
+            }
+            int end = start + 1;
+            while (end < length && text.charAt(end) != ' ') {
+                end++;
+            }
+            words.add(text.substring(start, end));
+            start = end + 1;
+        }
+        return words;
     }
 
     private static Coords getWordCoords(Integer maxY, Integer maxX, TextLine textLine, String text, int magicValueForYHigherThanWord, int magicValueForYLowerThanWord, String wordString, List<Point> wordBaselinePoints) {

--- a/layoutanalyzer/src/test/java/LayoutProcTest.java
+++ b/layoutanalyzer/src/test/java/LayoutProcTest.java
@@ -389,6 +389,62 @@ public class LayoutProcTest {
     }
 
     @Test
+    public void recalculateTextLineContoursFromBaselinesCreatesContours() {
+        System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+
+        Mat image = new Mat(120, 220, CvType.CV_8UC3, new Scalar(255, 255, 255));
+        Imgproc.line(image, new Point(20, 50), new Point(200, 50), new Scalar(0, 0, 0), 3);
+        Imgproc.line(image, new Point(20, 85), new Point(200, 85), new Scalar(0, 0, 0), 3);
+
+        PcGts page = new PcGts();
+        page.getPage().setImageHeight(120);
+        page.getPage().setImageWidth(220);
+
+        TextRegion textRegion = new TextRegion();
+        TextLine firstLine = new TextLine();
+        firstLine.getBaseline().setPoints("20,50 200,50");
+        textRegion.getTextLines().add(firstLine);
+        TextLine secondLine = new TextLine();
+        secondLine.getBaseline().setPoints("20,85 200,85");
+        textRegion.getTextLines().add(secondLine);
+        page.getPage().getTextRegions().add(textRegion);
+
+        LayoutProc.recalculateTextLineContoursFromBaselines("synthetic", image, page, 1, 15, 6, 1, false);
+
+        for (TextLine textLine : textRegion.getTextLines()) {
+            Assert.assertNotNull(textLine.getCoords().getPoints());
+            assertThat(StringConverter.stringToPoint(textLine.getCoords().getPoints()), hasSize(greaterThan(3)));
+            Assert.assertNotNull(textLine.getTextStyle());
+            assertThat(textLine.getTextStyle().getxHeight(), greaterThanOrEqualTo(LayoutProc.MINIMUM_XHEIGHT));
+        }
+
+        image.release();
+    }
+
+    @Test
+    public void calcSeamImageKeepsLargeFloatPenaltiesFinite() {
+        System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+
+        Mat energy = new Mat(40, 240, CvType.CV_32F, new Scalar(1));
+        Imgproc.line(energy, new Point(15, 0), new Point(15, 39), new Scalar(1.0e20), 1);
+        Mat seam = OpenCVWrapper.newMat();
+
+        LayoutProc.calcSeamImage(energy, new Size(24, 4), seam);
+
+        float[] value = new float[1];
+        for (int y = 0; y < seam.height(); y++) {
+            for (int x = 0; x < seam.width(); x++) {
+                seam.get(y, x, value);
+                Assert.assertFalse(Float.isNaN(value[0]));
+                Assert.assertFalse(Float.isInfinite(value[0]));
+            }
+        }
+
+        energy.release();
+        seam.release();
+    }
+
+    @Test
     public void splitLinesIntoWordsCoordsXValuesShouldBeInOrder() {
         final TextLine textLine = new TextLine();
         textLine.setTextEquiv(new TextEquiv(null, "SeHoUT er WETLIODSEREN"));
@@ -804,5 +860,10 @@ public class LayoutProcTest {
         LayoutProc.safePut(zeros64F, 0, 0, 1.0);
         double one64F = LayoutProc.getSafeDouble(zeros64F, 0, 0);
         assertThat(one64F, is(1.0));
+
+        Mat zeros32F = OpenCVWrapper.zeros(new Size(100,100), CvType.CV_32F);
+        LayoutProc.safePut(zeros32F, 0, 0, 1.0);
+        double one32F = LayoutProc.getSafeDouble(zeros32F, 0, 0);
+        assertThat(one32F, is(1.0));
     }
 }

--- a/layoutanalyzer/src/test/java/RecalculateContoursBenchmark.java
+++ b/layoutanalyzer/src/test/java/RecalculateContoursBenchmark.java
@@ -1,0 +1,360 @@
+import nl.knaw.huc.di.images.layoutanalyzer.layoutlib.LayoutProc;
+import nl.knaw.huc.di.images.layoutanalyzer.layoutlib.OpenCVWrapper;
+import nl.knaw.huc.di.images.layoutds.models.Page.PcGts;
+import nl.knaw.huc.di.images.layoutds.models.Page.TextRegion;
+import nl.knaw.huc.di.images.pagexmlutils.PageUtils;
+import org.opencv.core.Core;
+import org.opencv.core.Mat;
+import org.opencv.imgcodecs.Imgcodecs;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+public class RecalculateContoursBenchmark {
+    private static final class Config {
+        private Path imageDir = Paths.get("/data/ijsberg/full/train");
+        private Path xmlDir = Paths.get("/data/ijsberg/full/train/page");
+        private Path csv = Paths.get("/tmp/recalculate-contours-benchmark.csv");
+        private String label = "benchmark";
+        private int limit = 20;
+        private int warmup = 1;
+        private int runs = 3;
+        private double scaleDownFactor = 4;
+        private int minimumInterlineDistance = 35;
+        private int thickness = 10;
+        private int minimumBaselineThickness = 1;
+        private boolean ignoreBroken = true;
+        private boolean ignoreXmlErrors = false;
+        private boolean suppressStderr = true;
+    }
+
+    private static final class Pair {
+        private final String stem;
+        private final Path image;
+        private final Path xml;
+
+        private Pair(String stem, Path image, Path xml) {
+            this.stem = stem;
+            this.image = image;
+            this.xml = xml;
+        }
+    }
+
+    private static final class Measurement {
+        private final String stem;
+        private final int run;
+        private final long elapsedNanos;
+        private final int width;
+        private final int height;
+        private final int lines;
+
+        private Measurement(String stem, int run, long elapsedNanos, int width, int height, int lines) {
+            this.stem = stem;
+            this.run = run;
+            this.elapsedNanos = elapsedNanos;
+            this.width = width;
+            this.height = height;
+            this.lines = lines;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Locale.setDefault(Locale.ROOT);
+        Config config = parseArgs(args);
+        System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+
+        List<Pair> pairs = selectPairs(findPairs(config), config.limit);
+        if (pairs.isEmpty()) {
+            throw new IllegalArgumentException("No image/xml pairs found in " + config.imageDir + " and " + config.xmlDir);
+        }
+
+        if (config.csv.getParent() != null) {
+            Files.createDirectories(config.csv.getParent());
+        }
+
+        List<Measurement> measurements = new ArrayList<>();
+        int failures = 0;
+        try (BufferedWriter writer = Files.newBufferedWriter(config.csv, StandardCharsets.UTF_8)) {
+            writer.write("label,stem,run,elapsed_ms,width,height,lines,status,error");
+            writer.newLine();
+
+            for (int i = 0; i < config.warmup; i++) {
+                failures += executeRun(config, pairs, -1, writer, null);
+                System.gc();
+            }
+
+            for (int run = 1; run <= config.runs; run++) {
+                failures += executeRun(config, pairs, run, writer, measurements);
+                System.gc();
+            }
+        }
+
+        List<Double> elapsedMillis = new ArrayList<>();
+        for (Measurement measurement : measurements) {
+            elapsedMillis.add(measurement.elapsedNanos / 1_000_000d);
+        }
+        Collections.sort(elapsedMillis);
+
+        double totalMillis = 0;
+        for (double elapsed : elapsedMillis) {
+            totalMillis += elapsed;
+        }
+
+        System.out.printf(Locale.ROOT,
+                "BENCHMARK_SUMMARY label=%s pairs=%d runs=%d measurements=%d failures=%d total_ms=%.3f median_ms=%.3f p95_ms=%.3f peak_rss_kb=%d csv=%s%n",
+                config.label,
+                pairs.size(),
+                config.runs,
+                measurements.size(),
+                failures,
+                totalMillis,
+                percentile(elapsedMillis, 0.50),
+                percentile(elapsedMillis, 0.95),
+                peakRssKb(),
+                config.csv);
+    }
+
+    private static int executeRun(Config config, List<Pair> pairs, int run, BufferedWriter writer,
+                                  List<Measurement> measurements) throws IOException {
+        int failures = 0;
+        for (Pair pair : pairs) {
+            Mat image = null;
+            try {
+                String xml = Files.readString(pair.xml);
+                PcGts page = PageUtils.readPageFromString(xml, config.ignoreXmlErrors);
+                if (page == null) {
+                    throw new IllegalStateException("PAGE parse returned null");
+                }
+
+                image = OpenCVWrapper.imread(pair.image.toString(), Imgcodecs.IMREAD_COLOR);
+                if (image.empty()) {
+                    throw new IllegalStateException("Image could not be read");
+                }
+                int lines = countLines(page);
+
+                long elapsed = measureRecalculate(config, pair, image, page);
+
+                if (run > 0) {
+                    Measurement measurement = new Measurement(pair.stem, run, elapsed, image.width(), image.height(), lines);
+                    measurements.add(measurement);
+                    writeCsv(writer, config.label, measurement, "ok", "");
+                }
+            } catch (Exception exception) {
+                failures++;
+                if (run > 0) {
+                    writer.write(csv(config.label));
+                    writer.write(",");
+                    writer.write(csv(pair.stem));
+                    writer.write(",");
+                    writer.write(Integer.toString(run));
+                    writer.write(",,,,,error,");
+                    writer.write(csv(exception.getClass().getSimpleName() + ": " + exception.getMessage()));
+                    writer.newLine();
+                }
+            } finally {
+                if (image != null && image.dataAddr() != 0) {
+                    image = OpenCVWrapper.release(image);
+                }
+            }
+        }
+        return failures;
+    }
+
+    private static long measureRecalculate(Config config, Pair pair, Mat image, PcGts page) {
+        PrintStream originalErr = System.err;
+        PrintStream mutedErr = null;
+        if (config.suppressStderr) {
+            mutedErr = new PrintStream(OutputStream.nullOutputStream());
+            System.setErr(mutedErr);
+        }
+
+        long start = System.nanoTime();
+        try {
+            LayoutProc.recalculateTextLineContoursFromBaselines(
+                    pair.stem,
+                    image,
+                    page,
+                    config.scaleDownFactor,
+                    config.minimumInterlineDistance,
+                    config.thickness,
+                    config.minimumBaselineThickness,
+                    config.ignoreBroken);
+            return System.nanoTime() - start;
+        } finally {
+            if (mutedErr != null) {
+                System.setErr(originalErr);
+                mutedErr.close();
+            }
+        }
+    }
+
+    private static void writeCsv(BufferedWriter writer, String label, Measurement measurement,
+                                 String status, String error) throws IOException {
+        writer.write(csv(label));
+        writer.write(",");
+        writer.write(csv(measurement.stem));
+        writer.write(",");
+        writer.write(Integer.toString(measurement.run));
+        writer.write(",");
+        writer.write(String.format(Locale.ROOT, "%.3f", measurement.elapsedNanos / 1_000_000d));
+        writer.write(",");
+        writer.write(Integer.toString(measurement.width));
+        writer.write(",");
+        writer.write(Integer.toString(measurement.height));
+        writer.write(",");
+        writer.write(Integer.toString(measurement.lines));
+        writer.write(",");
+        writer.write(csv(status));
+        writer.write(",");
+        writer.write(csv(error));
+        writer.newLine();
+    }
+
+    private static List<Pair> findPairs(Config config) throws IOException {
+        List<Pair> pairs = new ArrayList<>();
+        try (var images = Files.list(config.imageDir)) {
+            images.filter(path -> path.getFileName().toString().endsWith(".jpg"))
+                    .sorted(Comparator.comparing(path -> path.getFileName().toString()))
+                    .forEach(image -> {
+                        String stem = stem(image.getFileName().toString());
+                        Path xml = config.xmlDir.resolve(stem + ".xml");
+                        if (Files.isRegularFile(xml)) {
+                            pairs.add(new Pair(stem, image, xml));
+                        }
+                    });
+        }
+        return pairs;
+    }
+
+    private static List<Pair> selectPairs(List<Pair> pairs, int limit) {
+        if (limit <= 0 || limit >= pairs.size()) {
+            return pairs;
+        }
+
+        List<Pair> selected = new ArrayList<>(limit);
+        double step = (double) pairs.size() / (double) limit;
+        for (int i = 0; i < limit; i++) {
+            selected.add(pairs.get((int) Math.floor(i * step)));
+        }
+        return selected;
+    }
+
+    private static int countLines(PcGts page) {
+        int lines = 0;
+        for (TextRegion textRegion : page.getPage().getTextRegions()) {
+            lines += textRegion.getTextLines().size();
+        }
+        return lines;
+    }
+
+    private static double percentile(List<Double> values, double percentile) {
+        if (values.isEmpty()) {
+            return 0;
+        }
+        int index = (int) Math.ceil(percentile * values.size()) - 1;
+        index = Math.max(0, Math.min(index, values.size() - 1));
+        return values.get(index);
+    }
+
+    private static long peakRssKb() {
+        Path status = Paths.get("/proc/self/status");
+        if (!Files.isRegularFile(status)) {
+            return -1;
+        }
+        try {
+            for (String line : Files.readAllLines(status, StandardCharsets.UTF_8)) {
+                if (line.startsWith("VmHWM:")) {
+                    String value = line.substring("VmHWM:".length()).trim().split("\\s+")[0];
+                    return Long.parseLong(value);
+                }
+            }
+        } catch (IOException | NumberFormatException ignored) {
+            return -1;
+        }
+        return -1;
+    }
+
+    private static String stem(String filename) {
+        int index = filename.lastIndexOf('.');
+        return index >= 0 ? filename.substring(0, index) : filename;
+    }
+
+    private static String csv(String value) {
+        if (value == null) {
+            return "";
+        }
+        return "\"" + value.replace("\"", "\"\"") + "\"";
+    }
+
+    private static Config parseArgs(String[] args) {
+        Config config = new Config();
+        for (int i = 0; i < args.length; i++) {
+            String arg = args[i];
+            switch (arg) {
+                case "--image-dir":
+                    config.imageDir = Paths.get(value(args, ++i, arg));
+                    break;
+                case "--xml-dir":
+                    config.xmlDir = Paths.get(value(args, ++i, arg));
+                    break;
+                case "--csv":
+                    config.csv = Paths.get(value(args, ++i, arg));
+                    break;
+                case "--label":
+                    config.label = value(args, ++i, arg);
+                    break;
+                case "--limit":
+                    config.limit = Integer.parseInt(value(args, ++i, arg));
+                    break;
+                case "--warmup":
+                    config.warmup = Integer.parseInt(value(args, ++i, arg));
+                    break;
+                case "--runs":
+                    config.runs = Integer.parseInt(value(args, ++i, arg));
+                    break;
+                case "--scale":
+                    config.scaleDownFactor = Double.parseDouble(value(args, ++i, arg));
+                    break;
+                case "--minimum-interline-distance":
+                    config.minimumInterlineDistance = Integer.parseInt(value(args, ++i, arg));
+                    break;
+                case "--thickness":
+                    config.thickness = Integer.parseInt(value(args, ++i, arg));
+                    break;
+                case "--minimum-baseline-thickness":
+                    config.minimumBaselineThickness = Integer.parseInt(value(args, ++i, arg));
+                    break;
+                case "--ignore-broken":
+                    config.ignoreBroken = Boolean.parseBoolean(value(args, ++i, arg));
+                    break;
+                case "--ignore-xml-errors":
+                    config.ignoreXmlErrors = Boolean.parseBoolean(value(args, ++i, arg));
+                    break;
+                case "--suppress-stderr":
+                    config.suppressStderr = Boolean.parseBoolean(value(args, ++i, arg));
+                    break;
+                default:
+                    throw new IllegalArgumentException("Unknown argument: " + arg);
+            }
+        }
+        return config;
+    }
+
+    private static String value(String[] args, int index, String arg) {
+        if (index >= args.length) {
+            throw new IllegalArgumentException("Missing value for " + arg);
+        }
+        return args[index];
+    }
+}

--- a/layoutanalyzer/src/test/java/RecalculateContoursBenchmarkTest.java
+++ b/layoutanalyzer/src/test/java/RecalculateContoursBenchmarkTest.java
@@ -1,0 +1,39 @@
+import org.junit.Assume;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RecalculateContoursBenchmarkTest {
+    @Test
+    public void runBenchmark() throws Exception {
+        Assume.assumeTrue(Boolean.getBoolean("benchmark.enabled"));
+
+        List<String> args = new ArrayList<>();
+        add(args, "--image-dir", "benchmark.imageDir");
+        add(args, "--xml-dir", "benchmark.xmlDir");
+        add(args, "--csv", "benchmark.csv");
+        add(args, "--label", "benchmark.label");
+        add(args, "--limit", "benchmark.limit");
+        add(args, "--warmup", "benchmark.warmup");
+        add(args, "--runs", "benchmark.runs");
+        add(args, "--scale", "benchmark.scale");
+        add(args, "--minimum-interline-distance", "benchmark.minimumInterlineDistance");
+        add(args, "--thickness", "benchmark.thickness");
+        add(args, "--minimum-baseline-thickness", "benchmark.minimumBaselineThickness");
+        add(args, "--ignore-broken", "benchmark.ignoreBroken");
+        add(args, "--ignore-xml-errors", "benchmark.ignoreXmlErrors");
+        add(args, "--suppress-stderr", "benchmark.suppressStderr");
+
+        RecalculateContoursBenchmark.main(args.toArray(new String[0]));
+    }
+
+    private static void add(List<String> args, String flag, String property) {
+        String value = System.getProperty(property);
+        if (value == null || value.isBlank()) {
+            return;
+        }
+        args.add(flag);
+        args.add(value);
+    }
+}

--- a/layoutanalyzer/src/test/java/SplitWordsBenchmark.java
+++ b/layoutanalyzer/src/test/java/SplitWordsBenchmark.java
@@ -1,12 +1,9 @@
 import nl.knaw.huc.di.images.layoutanalyzer.layoutlib.LayoutProc;
-import nl.knaw.huc.di.images.layoutanalyzer.layoutlib.OpenCVWrapper;
 import nl.knaw.huc.di.images.layoutds.models.Page.PcGts;
 import nl.knaw.huc.di.images.layoutds.models.Page.TextLine;
 import nl.knaw.huc.di.images.layoutds.models.Page.TextRegion;
 import nl.knaw.huc.di.images.pagexmlutils.PageUtils;
 import org.opencv.core.Core;
-import org.opencv.core.Mat;
-import org.opencv.imgcodecs.Imgcodecs;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -22,33 +19,25 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 
-public class RecalculateContoursBenchmark {
+public class SplitWordsBenchmark {
     private static final class Config {
         private Path imageDir = Paths.get("/data/ijsberg/full/train");
         private Path xmlDir = Paths.get("/data/ijsberg/full/train/page");
-        private Path csv = Paths.get("/tmp/recalculate-contours-benchmark.csv");
+        private Path csv = Paths.get("/tmp/split-words-benchmark.csv");
         private String label = "benchmark";
         private int limit = 20;
         private int warmup = 1;
         private int runs = 3;
-        private double scaleDownFactor = 4;
-        private int minimumInterlineDistance = 35;
-        private int thickness = 10;
-        private int minimumBaselineThickness = 1;
-        private boolean ignoreBroken = true;
         private boolean ignoreXmlErrors = false;
         private boolean suppressStderr = true;
-        private Path dumpContours = null;
     }
 
     private static final class Pair {
         private final String stem;
-        private final Path image;
         private final Path xml;
 
-        private Pair(String stem, Path image, Path xml) {
+        private Pair(String stem, Path xml) {
             this.stem = stem;
-            this.image = image;
             this.xml = xml;
         }
     }
@@ -57,17 +46,15 @@ public class RecalculateContoursBenchmark {
         private final String stem;
         private final int run;
         private final long elapsedNanos;
-        private final int width;
-        private final int height;
         private final int lines;
+        private final int words;
 
-        private Measurement(String stem, int run, long elapsedNanos, int width, int height, int lines) {
+        private Measurement(String stem, int run, long elapsedNanos, int lines, int words) {
             this.stem = stem;
             this.run = run;
             this.elapsedNanos = elapsedNanos;
-            this.width = width;
-            this.height = height;
             this.lines = lines;
+            this.words = words;
         }
     }
 
@@ -78,7 +65,7 @@ public class RecalculateContoursBenchmark {
 
         List<Pair> pairs = selectPairs(findPairs(config), config.limit);
         if (pairs.isEmpty()) {
-            throw new IllegalArgumentException("No image/xml pairs found in " + config.imageDir + " and " + config.xmlDir);
+            throw new IllegalArgumentException("No xml pairs found in " + config.xmlDir);
         }
 
         if (config.csv.getParent() != null) {
@@ -87,34 +74,18 @@ public class RecalculateContoursBenchmark {
 
         List<Measurement> measurements = new ArrayList<>();
         int failures = 0;
-        BufferedWriter dumpWriter = null;
-        if (config.dumpContours != null) {
-            if (config.dumpContours.getParent() != null) {
-                Files.createDirectories(config.dumpContours.getParent());
-            }
-            dumpWriter = Files.newBufferedWriter(config.dumpContours, StandardCharsets.UTF_8);
-            dumpWriter.write("stem\tlineId\tcontour");
-            dumpWriter.newLine();
-        }
         try (BufferedWriter writer = Files.newBufferedWriter(config.csv, StandardCharsets.UTF_8)) {
-            writer.write("label,stem,run,elapsed_ms,width,height,lines,status,error");
+            writer.write("label,stem,run,elapsed_ms,lines,words,status,error");
             writer.newLine();
 
             for (int i = 0; i < config.warmup; i++) {
-                failures += executeRun(config, pairs, -1, writer, null, null);
+                failures += executeRun(config, pairs, -1, writer, null);
                 System.gc();
             }
 
             for (int run = 1; run <= config.runs; run++) {
-                // Only dump contours during run 1 to keep the dump deterministic
-                // and avoid quadrupling the file size.
-                BufferedWriter dumpForRun = run == 1 ? dumpWriter : null;
-                failures += executeRun(config, pairs, run, writer, measurements, dumpForRun);
+                failures += executeRun(config, pairs, run, writer, measurements);
                 System.gc();
-            }
-        } finally {
-            if (dumpWriter != null) {
-                dumpWriter.close();
             }
         }
 
@@ -144,32 +115,24 @@ public class RecalculateContoursBenchmark {
     }
 
     private static int executeRun(Config config, List<Pair> pairs, int run, BufferedWriter writer,
-                                  List<Measurement> measurements, BufferedWriter dumpWriter) throws IOException {
+                                  List<Measurement> measurements) throws IOException {
         int failures = 0;
         for (Pair pair : pairs) {
-            Mat image = null;
             try {
                 String xml = Files.readString(pair.xml);
                 PcGts page = PageUtils.readPageFromString(xml, config.ignoreXmlErrors);
                 if (page == null) {
                     throw new IllegalStateException("PAGE parse returned null");
                 }
-
-                image = OpenCVWrapper.imread(pair.image.toString(), Imgcodecs.IMREAD_COLOR);
-                if (image.empty()) {
-                    throw new IllegalStateException("Image could not be read");
-                }
                 int lines = countLines(page);
 
-                long elapsed = measureRecalculate(config, pair, image, page);
+                long elapsed = measureSplit(config, page);
 
+                int words = countWords(page);
                 if (run > 0) {
-                    Measurement measurement = new Measurement(pair.stem, run, elapsed, image.width(), image.height(), lines);
+                    Measurement measurement = new Measurement(pair.stem, run, elapsed, lines, words);
                     measurements.add(measurement);
                     writeCsv(writer, config.label, measurement, "ok", "");
-                    if (dumpWriter != null) {
-                        dumpContours(dumpWriter, pair.stem, page);
-                    }
                 }
             } catch (Exception exception) {
                 failures++;
@@ -179,20 +142,16 @@ public class RecalculateContoursBenchmark {
                     writer.write(csv(pair.stem));
                     writer.write(",");
                     writer.write(Integer.toString(run));
-                    writer.write(",,,,,error,");
+                    writer.write(",,,,error,");
                     writer.write(csv(exception.getClass().getSimpleName() + ": " + exception.getMessage()));
                     writer.newLine();
-                }
-            } finally {
-                if (image != null && image.dataAddr() != 0) {
-                    image = OpenCVWrapper.release(image);
                 }
             }
         }
         return failures;
     }
 
-    private static long measureRecalculate(Config config, Pair pair, Mat image, PcGts page) {
+    private static long measureSplit(Config config, PcGts page) {
         PrintStream originalErr = System.err;
         PrintStream mutedErr = null;
         if (config.suppressStderr) {
@@ -202,15 +161,7 @@ public class RecalculateContoursBenchmark {
 
         long start = System.nanoTime();
         try {
-            LayoutProc.recalculateTextLineContoursFromBaselines(
-                    pair.stem,
-                    image,
-                    page,
-                    config.scaleDownFactor,
-                    config.minimumInterlineDistance,
-                    config.thickness,
-                    config.minimumBaselineThickness,
-                    config.ignoreBroken);
+            LayoutProc.splitLinesIntoWords(page);
             return System.nanoTime() - start;
         } finally {
             if (mutedErr != null) {
@@ -230,11 +181,9 @@ public class RecalculateContoursBenchmark {
         writer.write(",");
         writer.write(String.format(Locale.ROOT, "%.3f", measurement.elapsedNanos / 1_000_000d));
         writer.write(",");
-        writer.write(Integer.toString(measurement.width));
-        writer.write(",");
-        writer.write(Integer.toString(measurement.height));
-        writer.write(",");
         writer.write(Integer.toString(measurement.lines));
+        writer.write(",");
+        writer.write(Integer.toString(measurement.words));
         writer.write(",");
         writer.write(csv(status));
         writer.write(",");
@@ -251,7 +200,7 @@ public class RecalculateContoursBenchmark {
                         String stem = stem(image.getFileName().toString());
                         Path xml = config.xmlDir.resolve(stem + ".xml");
                         if (Files.isRegularFile(xml)) {
-                            pairs.add(new Pair(stem, image, xml));
+                            pairs.add(new Pair(stem, xml));
                         }
                     });
         }
@@ -262,7 +211,6 @@ public class RecalculateContoursBenchmark {
         if (limit <= 0 || limit >= pairs.size()) {
             return pairs;
         }
-
         List<Pair> selected = new ArrayList<>(limit);
         double step = (double) pairs.size() / (double) limit;
         for (int i = 0; i < limit; i++) {
@@ -271,32 +219,24 @@ public class RecalculateContoursBenchmark {
         return selected;
     }
 
-    private static void dumpContours(BufferedWriter writer, String stem, PcGts page) throws IOException {
-        // Stable, sortable per-line dump for equivalence checking across optimization
-        // runs. Format: <stem>\t<lineId>\t<x1,y1 x2,y2 ...>. Lines emitted in
-        // (region order, line order) — same as the in-memory page traversal.
-        for (TextRegion textRegion : page.getPage().getTextRegions()) {
-            for (TextLine textLine : textRegion.getTextLines()) {
-                String coords = "";
-                if (textLine.getCoords() != null && textLine.getCoords().getPoints() != null) {
-                    coords = textLine.getCoords().getPoints();
-                }
-                writer.write(stem);
-                writer.write('\t');
-                writer.write(textLine.getId() == null ? "" : textLine.getId());
-                writer.write('\t');
-                writer.write(coords);
-                writer.newLine();
-            }
-        }
-    }
-
     private static int countLines(PcGts page) {
         int lines = 0;
         for (TextRegion textRegion : page.getPage().getTextRegions()) {
             lines += textRegion.getTextLines().size();
         }
         return lines;
+    }
+
+    private static int countWords(PcGts page) {
+        int words = 0;
+        for (TextRegion textRegion : page.getPage().getTextRegions()) {
+            for (TextLine textLine : textRegion.getTextLines()) {
+                if (textLine.getWords() != null) {
+                    words += textLine.getWords().size();
+                }
+            }
+        }
+        return words;
     }
 
     private static double percentile(List<Double> values, double percentile) {
@@ -364,29 +304,11 @@ public class RecalculateContoursBenchmark {
                 case "--runs":
                     config.runs = Integer.parseInt(value(args, ++i, arg));
                     break;
-                case "--scale":
-                    config.scaleDownFactor = Double.parseDouble(value(args, ++i, arg));
-                    break;
-                case "--minimum-interline-distance":
-                    config.minimumInterlineDistance = Integer.parseInt(value(args, ++i, arg));
-                    break;
-                case "--thickness":
-                    config.thickness = Integer.parseInt(value(args, ++i, arg));
-                    break;
-                case "--minimum-baseline-thickness":
-                    config.minimumBaselineThickness = Integer.parseInt(value(args, ++i, arg));
-                    break;
-                case "--ignore-broken":
-                    config.ignoreBroken = Boolean.parseBoolean(value(args, ++i, arg));
-                    break;
                 case "--ignore-xml-errors":
                     config.ignoreXmlErrors = Boolean.parseBoolean(value(args, ++i, arg));
                     break;
                 case "--suppress-stderr":
                     config.suppressStderr = Boolean.parseBoolean(value(args, ++i, arg));
-                    break;
-                case "--dump-contours":
-                    config.dumpContours = Paths.get(value(args, ++i, arg));
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown argument: " + arg);

--- a/layoutanalyzer/src/test/java/SplitWordsBenchmarkTest.java
+++ b/layoutanalyzer/src/test/java/SplitWordsBenchmarkTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-public class RecalculateContoursBenchmarkTest {
+public class SplitWordsBenchmarkTest {
     @Test
     public void runBenchmark() throws Exception {
         Assume.assumeTrue(Boolean.getBoolean("benchmark.enabled"));
@@ -17,16 +17,10 @@ public class RecalculateContoursBenchmarkTest {
         add(args, "--limit", "benchmark.limit");
         add(args, "--warmup", "benchmark.warmup");
         add(args, "--runs", "benchmark.runs");
-        add(args, "--scale", "benchmark.scale");
-        add(args, "--minimum-interline-distance", "benchmark.minimumInterlineDistance");
-        add(args, "--thickness", "benchmark.thickness");
-        add(args, "--minimum-baseline-thickness", "benchmark.minimumBaselineThickness");
-        add(args, "--ignore-broken", "benchmark.ignoreBroken");
         add(args, "--ignore-xml-errors", "benchmark.ignoreXmlErrors");
         add(args, "--suppress-stderr", "benchmark.suppressStderr");
-        add(args, "--dump-contours", "benchmark.dumpContours");
 
-        RecalculateContoursBenchmark.main(args.toArray(new String[0]));
+        SplitWordsBenchmark.main(args.toArray(new String[0]));
     }
 
     private static void add(List<String> args, String flag, String property) {

--- a/loghiwebservice/src/main/java/nl/knaw/huc/di/images/loghiwebservice/LoghiWebserviceApplication.java
+++ b/loghiwebservice/src/main/java/nl/knaw/huc/di/images/loghiwebservice/LoghiWebserviceApplication.java
@@ -44,6 +44,7 @@ public class LoghiWebserviceApplication extends Application<LoghiWebserviceConfi
         configuration.registerRecalculateReadingOrderNewResource(environment, metricRegistry);
         configuration.registerSplitPageXMLTextLineIntoWordsResource(environment, metricRegistry);
         configuration.registerDetectLanguageOfPageXmlResource(environment, metricRegistry);
+        configuration.registerExtractAndCutResource(environment, metricRegistry);
 
         configuration.registerSecurity(environment);
 

--- a/loghiwebservice/src/main/java/nl/knaw/huc/di/images/loghiwebservice/LoghiWebserviceConfiguration.java
+++ b/loghiwebservice/src/main/java/nl/knaw/huc/di/images/loghiwebservice/LoghiWebserviceConfiguration.java
@@ -43,6 +43,9 @@ public class LoghiWebserviceConfiguration extends Configuration {
     private ExecutorServiceConfig detectLanguageOfPageXmlResourceExecutorService;
 
     @JsonProperty
+    private ExecutorServiceConfig extractAndCutExecutorServiceConfig;
+
+    @JsonProperty
     private SecurityConfig securityConfig;
 
     public void registerExtractBaseLinesResource(Environment environment, MetricRegistry metricRegistry) {
@@ -82,6 +85,13 @@ public class LoghiWebserviceConfiguration extends Configuration {
         final ExecutorService executorService = detectLanguageOfPageXmlResourceExecutorService.createExecutorService(environment, metricRegistry);
         final Supplier<String> queueUsageStatusSupplier = detectLanguageOfPageXmlResourceExecutorService.createQueueUsageStatusSupplier(metricRegistry);
         environment.jersey().register(new DetectLanguageOfPageXmlResource(uploadLocation, executorService, queueUsageStatusSupplier, detectLanguageOfPageXmlResourceExecutorService.getLedgerSize()));
+    }
+
+    public void registerExtractAndCutResource(Environment environment, MetricRegistry metricRegistry) {
+        final ExecutorService executorService = extractAndCutExecutorServiceConfig.createExecutorService(environment, metricRegistry);
+        final Supplier<String> queueUsageStatusSupplier = extractAndCutExecutorServiceConfig.createQueueUsageStatusSupplier(metricRegistry);
+        environment.jersey().register(new ExtractAndCutResource(executorService, uploadLocation, p2palaConfigFile,
+                laypaConfig, queueUsageStatusSupplier, extractAndCutExecutorServiceConfig.getLedgerSize()));
     }
 
     public void registerSecurity(Environment environment) {

--- a/loghiwebservice/src/main/java/nl/knaw/huc/di/images/loghiwebservice/resources/CutFromImageBasedOnPageXMLNewResource.java
+++ b/loghiwebservice/src/main/java/nl/knaw/huc/di/images/loghiwebservice/resources/CutFromImageBasedOnPageXMLNewResource.java
@@ -132,7 +132,7 @@ public class CutFromImageBasedOnPageXMLNewResource extends LoghiWebserviceResour
         final boolean outputConfFile = getFieldOrDefaultValue(Boolean.class, multiPart, fields, "output_conf_file", false);
         final boolean outputBoxFile = getFieldOrDefaultValue(Boolean.class, multiPart, fields, "output_box_file", true);
         final boolean outputTxtFile = getFieldOrDefaultValue(Boolean.class, multiPart, fields, "output_txt_file", true);
-        final boolean recalculateTextLineContoursFromBaselines = getFieldOrDefaultValue(Boolean.class, multiPart, fields, "recalculate_text_line_contours_from_baselines", true);
+        final boolean recalculateTextLineContoursFromBaselines = getFieldOrDefaultValue(Boolean.class, multiPart, fields, "recalculate_text_line_contours_from_baselines", false);
         final Integer fixedXHeight = getFieldOrDefaultValue(Integer.class, multiPart, fields, "fixed_x_height", null);
         final int minimumXHeight = getFieldOrDefaultValue(Integer.class, multiPart, fields, "min_x_height", LayoutProc.MINIMUM_XHEIGHT);
         final boolean includeTextStyles = getFieldOrDefaultValue(Boolean.class, multiPart, fields, "include_text_styles", false);

--- a/loghiwebservice/src/main/java/nl/knaw/huc/di/images/loghiwebservice/resources/ExtractAndCutResource.java
+++ b/loghiwebservice/src/main/java/nl/knaw/huc/di/images/loghiwebservice/resources/ExtractAndCutResource.java
@@ -1,0 +1,263 @@
+package nl.knaw.huc.di.images.loghiwebservice.resources;
+
+import com.codahale.metrics.annotation.Timed;
+import nl.knaw.huc.di.images.layoutanalyzer.layoutlib.LayoutProc;
+import nl.knaw.huc.di.images.layoutds.models.LaypaConfig;
+import nl.knaw.huc.di.images.layoutds.models.P2PaLAConfig;
+import nl.knaw.huc.di.images.layoutds.models.Page.PcGts;
+import nl.knaw.huc.di.images.minions.MinionCutFromImageBasedOnPageXMLNew;
+import nl.knaw.huc.di.images.minions.MinionExtractBaselines;
+import nl.knaw.huc.di.images.pagexmlutils.PageUtils;
+import nl.knaw.huc.di.images.pipelineutils.ErrorFileWriter;
+import org.apache.commons.io.IOUtils;
+import org.glassfish.jersey.media.multipart.FormDataBodyPart;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.json.simple.parser.ParseException;
+import org.opencv.core.Mat;
+import org.opencv.core.MatOfByte;
+import org.opencv.imgcodecs.Imgcodecs;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.security.PermitAll;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
+import java.util.*;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import static nl.knaw.huc.di.images.loghiwebservice.resources.FormMultipartHelper.getFieldOrDefaultValue;
+
+@Path("/extract-and-cut")
+@Produces(MediaType.APPLICATION_JSON)
+public class ExtractAndCutResource extends LoghiWebserviceResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ExtractAndCutResource.class);
+
+    private final ExecutorService executorService;
+    private final String uploadLocation;
+    private final String p2palaConfigFile;
+    private final String laypaConfigFile;
+    private final Supplier<String> queueUsageStatusSupplier;
+    private final StringBuffer minionErrorLog;
+    private final ErrorFileWriter errorFileWriter;
+
+    public ExtractAndCutResource(ExecutorService executorService, String uploadLocation,
+                                 String p2palaConfigFile, String laypaConfigFile,
+                                 Supplier<String> queueUsageStatusSupplier, int ledgerSize) {
+        super(ledgerSize);
+        this.executorService = executorService;
+        this.uploadLocation = uploadLocation;
+        this.p2palaConfigFile = p2palaConfigFile;
+        this.laypaConfigFile = laypaConfigFile;
+        this.queueUsageStatusSupplier = queueUsageStatusSupplier;
+        this.minionErrorLog = new StringBuffer();
+        this.errorFileWriter = new ErrorFileWriter(uploadLocation);
+    }
+
+    @PermitAll
+    @POST
+    @Timed
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    public Response schedule(FormDataMultiPart multiPart) {
+        if (minionErrorLog.length() > 0) {
+            return Response.serverError().entity("Minion is failing: " + minionErrorLog).build();
+        }
+
+        final Map<String, List<FormDataBodyPart>> fields = multiPart.getFields();
+        if (!fields.containsKey("image"))      return missingField("image");
+        if (!fields.containsKey("mask"))       return missingField("mask");
+        if (!fields.containsKey("xml"))        return missingField("xml");
+        if (!fields.containsKey("identifier")) return missingField("identifier");
+        if (!fields.containsKey("output_type")) return missingField("output_type");
+        if (!fields.containsKey("channels"))   return missingField("channels");
+
+        final String identifier = multiPart.getField("identifier").getValue();
+
+        // --- image ---
+        FormDataBodyPart imageUpload = multiPart.getField("image");
+        FormDataContentDisposition imageDisposition = imageUpload.getFormDataContentDisposition();
+        String imageFile = imageDisposition.getFileName();
+        final byte[] imageArray;
+        try {
+            imageArray = IOUtils.toByteArray(imageUpload.getValueAs(InputStream.class));
+        } catch (IOException e) {
+            errorFileWriter.write(identifier, e, "Could not read image");
+            return Response.serverError().entity("{\"message\":\"Could not read image\"}").build();
+        }
+        Supplier<Mat> imageSupplier = () -> Imgcodecs.imdecode(new MatOfByte(imageArray), Imgcodecs.IMREAD_COLOR);
+
+        // --- mask ---
+        FormDataBodyPart maskUpload = multiPart.getField("mask");
+        String maskFile = maskUpload.getFormDataContentDisposition().getFileName();
+        final byte[] maskArray;
+        try {
+            maskArray = IOUtils.toByteArray(maskUpload.getValueAs(InputStream.class));
+        } catch (IOException e) {
+            errorFileWriter.write(identifier, e, "Could not read mask");
+            return Response.serverError().entity("{\"message\":\"Could not read mask\"}").build();
+        }
+        Supplier<Mat> maskSupplier = () -> Imgcodecs.imdecode(new MatOfByte(maskArray), Imgcodecs.IMREAD_GRAYSCALE);
+
+        // --- xml ---
+        FormDataBodyPart xmlUpload = multiPart.getField("xml");
+        String xmlFile = xmlUpload.getFormDataContentDisposition().getFileName();
+        final String xmlString;
+        try {
+            xmlString = IOUtils.toString(xmlUpload.getValueAs(InputStream.class), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            errorFileWriter.write(identifier, e, "Could not read page xml");
+            return Response.serverError().entity("{\"message\":\"Could not read page xml\"}").build();
+        }
+
+        // --- extract-baselines params ---
+        String namespace = PageUtils.NAMESPACE2019;
+        if (fields.containsKey("namespace")) {
+            namespace = multiPart.getField("namespace").getValue();
+            if (!PageUtils.NAMESPACE2013.equals(namespace) && !PageUtils.NAMESPACE2019.equals(namespace)) {
+                return Response.status(400).entity("{\"message\":\"Unsupported namespace\"}").build();
+            }
+        }
+        final int margin = fields.containsKey("margin")
+                ? multiPart.getField("margin").getValueAs(Integer.class) : 50;
+        final boolean invertImage = fields.containsKey("invertImage")
+                && "true".equals(multiPart.getField("invertImage").getValue());
+        final boolean addLaypaMetadata = fields.containsKey("addLaypaMetadata")
+                && "true".equals(multiPart.getField("addLaypaMetadata").getValue());
+        final boolean splitBaselines = fields.containsKey("splitBaselines")
+                && "true".equals(multiPart.getField("splitBaselines").getValue());
+        final List<String> whiteList = fields.containsKey("config_white_list")
+                ? fields.get("config_white_list").stream().map(FormDataBodyPart::getValue).collect(Collectors.toList())
+                : new ArrayList<>();
+
+        P2PaLAConfig p2palaConfig = null;
+        LaypaConfig laypaConfig = null;
+        if (invertImage) {
+            try {
+                p2palaConfig = fields.containsKey("p2pala_config")
+                        ? MinionExtractBaselines.readP2PaLAConfigFile(multiPart.getField("p2pala_config").getValueAs(InputStream.class), whiteList)
+                        : MinionExtractBaselines.readP2PaLAConfigFile(p2palaConfigFile, whiteList);
+            } catch (IOException | ParseException e) {
+                LOG.error("Could not read p2palaConfig", e);
+            }
+        } else if (addLaypaMetadata) {
+            try {
+                laypaConfig = fields.containsKey("laypa_config")
+                        ? MinionExtractBaselines.readLaypaConfigFile(multiPart.getField("laypa_config").getValueAs(InputStream.class), whiteList)
+                        : MinionExtractBaselines.readLaypaConfigFile(laypaConfigFile, whiteList);
+            } catch (IOException | ParseException e) {
+                LOG.error("Could not read laypaConfig", e);
+            }
+        }
+
+        // --- cut-from-image params ---
+        final String outputType = multiPart.getField("output_type").getValue();
+        final int channels = multiPart.getField("channels").getValueAs(Integer.class);
+        final int minWidth = getFieldOrDefaultValue(Integer.class, multiPart, fields, "min_width", 5);
+        final int minHeight = getFieldOrDefaultValue(Integer.class, multiPart, fields, "min_height", 5);
+        final int minWidthToHeight = getFieldOrDefaultValue(Integer.class, multiPart, fields, "min_width_to_height_ratio", 0);
+        final boolean writeTextContents = getFieldOrDefaultValue(Boolean.class, multiPart, fields, "write_text_contents", false);
+        final Integer rescaleHeight = getFieldOrDefaultValue(Integer.class, multiPart, fields, "rescale_height", null);
+        final boolean outputConfFile = getFieldOrDefaultValue(Boolean.class, multiPart, fields, "output_conf_file", false);
+        final boolean outputBoxFile = getFieldOrDefaultValue(Boolean.class, multiPart, fields, "output_box_file", true);
+        final boolean outputTxtFile = getFieldOrDefaultValue(Boolean.class, multiPart, fields, "output_txt_file", true);
+        final Integer fixedXHeight = getFieldOrDefaultValue(Integer.class, multiPart, fields, "fixed_x_height", null);
+        final int minimumXHeight = getFieldOrDefaultValue(Integer.class, multiPart, fields, "min_x_height", LayoutProc.MINIMUM_XHEIGHT);
+        final boolean includeTextStyles = getFieldOrDefaultValue(Boolean.class, multiPart, fields, "include_text_styles", false);
+        final boolean useTags = getFieldOrDefaultValue(Boolean.class, multiPart, fields, "use_tags", false);
+        final int minimumBaselineThickness = getFieldOrDefaultValue(Integer.class, multiPart, fields, "minimum_baseline_thickness", 1);
+
+        // --- output paths ---
+        final String outputXmlFile = Paths.get(uploadLocation, identifier, xmlFile).toAbsolutePath().toString();
+        final String outputBase = Paths.get(uploadLocation, identifier).toAbsolutePath().toString();
+        final String finalNamespace = namespace;
+        final P2PaLAConfig finalP2palaConfig = p2palaConfig;
+        final LaypaConfig finalLaypaConfig = laypaConfig;
+
+        // --- fused job ---
+        // The capturing supplier lets MinionExtractBaselines modify the page in-place.
+        // After its run() completes, pageHolder contains the fully updated page
+        // (baselines extracted + contours recalculated), which we pass directly to the
+        // cut minion — no disk round-trip, no duplicate seam DP.
+        final AtomicReference<PcGts> pageHolder = new AtomicReference<>();
+        final Supplier<PcGts> capturingPageSupplier = () -> {
+            PcGts page = PageUtils.readPageFromString(xmlString);
+            pageHolder.set(page);
+            return page;
+        };
+
+        Runnable job = () -> {
+            new MinionExtractBaselines(identifier, capturingPageSupplier, imageSupplier,
+                    outputXmlFile, true, finalP2palaConfig, finalLaypaConfig, maskSupplier,
+                    margin, invertImage,
+                    error -> minionErrorLog.append(error).append("\n"),
+                    32, new ArrayList<>(), finalNamespace, true,
+                    Optional.of(errorFileWriter), splitBaselines, 1.2, 1.5,
+                    minimumBaselineThickness)
+                    .run();
+
+            PcGts updatedPage = pageHolder.get();
+            if (updatedPage == null) {
+                LOG.error("{}: extract-baselines did not produce a page, skipping cut step", identifier);
+                return;
+            }
+
+            new MinionCutFromImageBasedOnPageXMLNew(
+                    identifier, imageSupplier, () -> updatedPage,
+                    outputBase, imageFile, false,
+                    minWidth, minHeight, minWidthToHeight, outputType, channels,
+                    writeTextContents, rescaleHeight, outputConfFile, outputBoxFile, outputTxtFile,
+                    false, // recalculate=false: contours are already fresh from extract step
+                    fixedXHeight, minimumXHeight,
+                    false, false, false,
+                    error -> minionErrorLog.append(error).append("\n"),
+                    includeTextStyles, useTags, false, null, null,
+                    MinionCutFromImageBasedOnPageXMLNew.DEFAULT_MINIMUM_INTERLINE_DISTANCE,
+                    MinionCutFromImageBasedOnPageXMLNew.DEFAULT_PNG_COMPRESSION_LEVEL,
+                    Optional.empty(), null, minimumBaselineThickness, 0)
+                    .run();
+        };
+
+        try {
+            if (identifier != null && statusLedger.containsKey(identifier)) {
+                LOG.warn("Identifier {} already in use", identifier);
+            }
+            Future<?> future = executorService.submit(job);
+            if (statusLedger.size() >= ledgerSize) {
+                try {
+                    while (statusLedger.size() >= ledgerSize) {
+                        statusLedger.remove(statusLedger.firstKey());
+                    }
+                } catch (Exception e) {
+                    LOG.error("Could not trim status ledger", e);
+                }
+            }
+            statusLedger.put(identifier, future);
+        } catch (RejectedExecutionException e) {
+            return Response.status(Response.Status.TOO_MANY_REQUESTS)
+                    .entity("{\"message\":\"Queue is full\"}").build();
+        }
+
+        String output = "{\"filesUploaded\": [\"" + maskFile + "\", \"" + xmlFile + "\", \"" + imageFile + "\"]," +
+                "\"queueStatus\": " + queueUsageStatusSupplier.get() + "}";
+        return Response.ok(output).build();
+    }
+
+    private Response missingField(String field) {
+        return Response.status(Response.Status.BAD_REQUEST)
+                .entity("{\"message\":\"missing field \\\"" + field + "\\\"\"}").build();
+    }
+}

--- a/loghiwebservice/src/main/resources/configuration.yml
+++ b/loghiwebservice/src/main/resources/configuration.yml
@@ -32,6 +32,12 @@ splitPageXMLTextLineIntoWordsResourceExecutorServiceConfig:
   queueLength: ${SPLIT_PAGE_TEXT_LINE_INTO_WORDS_QUEUE_LENGTH:- 50}
   ledgerSize: ${SPLIT_PAGE_TEXT_LINE_INTO_WORDS_LEDGER_SIZE:- 1000000}
 
+extractAndCutExecutorServiceConfig:
+  maxThreads: ${EXTRACT_AND_CUT_MAX_THREADS:- 1}
+  name: ExtractAndCut
+  queueLength: ${EXTRACT_AND_CUT_QUEUE_LENGTH:- 50}
+  ledgerSize: ${EXTRACT_AND_CUT_LEDGER_SIZE:- 1000000}
+
 detectLanguageOfPageXmlResourceExecutorService:
   maxThreads: ${DETECT_LANGUAGE_OF_PAGE_XML_MAX_THREADS:- 1}
   name: DetectLanguageOfPageXml

--- a/minions/pom.xml
+++ b/minions/pom.xml
@@ -24,6 +24,10 @@
                 </configuration>
             </plugin>
             <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>appassembler-maven-plugin</artifactId>
                 <version>2.1.0</version>
@@ -306,6 +310,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <version>5.9.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <version>5.9.1</version>
             <scope>test</scope>
         </dependency>

--- a/minions/src/main/java/nl/knaw/huc/di/images/minions/MinionCutFromImageBasedOnPageXMLNew.java
+++ b/minions/src/main/java/nl/knaw/huc/di/images/minions/MinionCutFromImageBasedOnPageXMLNew.java
@@ -522,9 +522,16 @@ public class MinionCutFromImageBasedOnPageXMLNew extends BaseMinion implements R
 
     private void runFile(Mat image) throws IOException {
         Stopwatch stopwatch = Stopwatch.createStarted();
-        Mat localImage = image.clone();
+        // Avoid a full-image clone on the default path (coffeeStains == 0). addCoffeeStains
+        // already clones internally, so we only need to release localImage when we owned it.
+        Mat localImage;
+        boolean ownsLocalImage;
         if (coffeeStains > 0) {
-            localImage = addCoffeeStains(localImage, coffeeStains);
+            localImage = addCoffeeStains(image, coffeeStains);
+            ownsLocalImage = true;
+        } else {
+            localImage = image;
+            ownsLocalImage = false;
         }
 
         try {
@@ -565,6 +572,10 @@ public class MinionCutFromImageBasedOnPageXMLNew extends BaseMinion implements R
             LOG.debug(identifier + "recalc: " + recalc.stop());
             List<TextLine> textLines = PageUtils.getTextLines(page, skipUnclear, minimumConfidence, maximumConfidence, ignoreBroken);
             StringBuilder allTextLineContents = new StringBuilder();
+            // Allocate PNG compression params once per page; reused for every line strip.
+            final boolean isPng = "png".equals(this.outputType);
+            MatOfInt pngParams = isPng ? new MatOfInt(Imgcodecs.IMWRITE_PNG_COMPRESSION, this.pngCompressionLevel) : null;
+            try {
             for (TextLine textLine : textLines) {
                 List<Point> contourPoints = StringConverter.stringToPoint(textLine.getCoords().getPoints());
                 if (contourPoints.isEmpty()) {
@@ -595,7 +606,11 @@ public class MinionCutFromImageBasedOnPageXMLNew extends BaseMinion implements R
                 Mat lineStripMat = null;
                 try {
                     if (binaryLineStrip != null && binaryLineStrip.getLineStrip() != null) {
-                        lineStripMat = binaryLineStrip.getLineStrip().clone();
+                        // Take ownership of the line strip directly. The finally block releases
+                        // lineStripMat; we transfer the reference out of binaryLineStrip so that
+                        // its cleanup is a no-op, avoiding a per-line full Mat clone.
+                        lineStripMat = binaryLineStrip.getLineStrip();
+                        binaryLineStrip.setLineStrip(null);
                         xHeight = binaryLineStrip.getxHeight();
                         if (textLine.getTextStyle() == null) {
                             textLine.setTextStyle(new TextStyle());
@@ -647,27 +662,27 @@ public class MinionCutFromImageBasedOnPageXMLNew extends BaseMinion implements R
                                     }
                                 }
                             }
-                            String outputPath = null;
+                            String outputPath;
                             if (this.useDiforNames) {
                                 outputPath = new File(balancedOutputBaseTmp, "textline_" + fileNameWithoutExtension + "_" + textLine.getId() + "." + this.outputType).getAbsolutePath();
                                 LOG.debug(identifier + " save snippet: " + outputPath);
-                                atomicImwrite(outputPath, lineStripMat);
                             } else {
                                 outputPath = new File(balancedOutputBaseTmp, lineStripId + "." + this.outputType).getAbsolutePath();
-                                try {
-                                    // from documentation opencv
-                                    // For PNG, it can be the compression level from 0 to 9. A higher value means a smaller size and longer compression time. If specified, strategy is changed to IMWRITE_PNG_STRATEGY_DEFAULT (Z_DEFAULT_STRATEGY). Default value is 1 (best speed setting).
-                                    if (this.outputType.equals("png")) {
-                                        writePngLineStrip(outputPath, lineStripMat);
-                                    } else {
-                                        atomicImwrite(outputPath, lineStripMat);
-                                    }
-
-                                } catch (Exception e) {
-                                    errorLog.accept("Cannot write " + outputPath);
-                                    lineStripMat = OpenCVWrapper.release(lineStripMat);
-                                    throw e;
+                            }
+                            try {
+                                // balancedOutputBaseTmp is a private tmp dir under tmpdir; the
+                                // whole dir is atomic-moved to its final home at the end of the
+                                // page. Per-line tmpfile-and-move is redundant here, so write
+                                // straight to the target path.
+                                if (isPng) {
+                                    writePngLineStrip(outputPath, lineStripMat, pngParams);
+                                } else {
+                                    Imgcodecs.imwrite(outputPath, lineStripMat);
                                 }
+                            } catch (Exception e) {
+                                errorLog.accept("Cannot write " + outputPath);
+                                lineStripMat = OpenCVWrapper.release(lineStripMat);
+                                throw e;
                             }
                             if (writeTextContents) {
                                 Double confidence = 1.;
@@ -693,6 +708,11 @@ public class MinionCutFromImageBasedOnPageXMLNew extends BaseMinion implements R
                     }
                 }
             }
+            } finally {
+                if (pngParams != null) {
+                    pngParams = OpenCVWrapper.release(pngParams);
+                }
+            }
             if (writeTextContents) {
                 StringTools.writeFile(new File(balancedOutputBaseTmp, "loghi-all-lines.txt").getAbsolutePath(), allTextLineContents.toString());
             }
@@ -712,7 +732,9 @@ public class MinionCutFromImageBasedOnPageXMLNew extends BaseMinion implements R
                 this.doneFileWriter.run();
             }
         } finally {
-            localImage = OpenCVWrapper.release(localImage); // Release localImage
+            if (ownsLocalImage) {
+                localImage = OpenCVWrapper.release(localImage);
+            }
         }
     }
 
@@ -751,13 +773,10 @@ public class MinionCutFromImageBasedOnPageXMLNew extends BaseMinion implements R
         }
     }
 
-    private void writePngLineStrip(String absolutePath, Mat lineStripMat) {
-        MatOfInt parametersMatOfInt = new MatOfInt(Imgcodecs.IMWRITE_PNG_COMPRESSION, this.pngCompressionLevel);
-        try {
-            atomicImwrite(absolutePath, lineStripMat, parametersMatOfInt);
-        } finally {
-            parametersMatOfInt = OpenCVWrapper.release(parametersMatOfInt);
-        }
+    private void writePngLineStrip(String absolutePath, Mat lineStripMat, MatOfInt pngParams) {
+        // pngParams is provided by the caller and reused across all line strips of a page,
+        // so we never allocate a fresh MatOfInt per line.
+        Imgcodecs.imwrite(absolutePath, lineStripMat, pngParams);
     }
 
     private static void deleteFolderRecursively(Path source) throws IOException {

--- a/minions/src/main/java/nl/knaw/huc/di/images/minions/MinionExtractBaselines.java
+++ b/minions/src/main/java/nl/knaw/huc/di/images/minions/MinionExtractBaselines.java
@@ -633,7 +633,7 @@ public class MinionExtractBaselines implements Runnable, AutoCloseable {
             LayoutProc.recalculateTextLineContoursFromBaselines(identifier, imageMat, page,
                     MinionCutFromImageBasedOnPageXMLNew.SHRINK_FACTOR,
                     MinionCutFromImageBasedOnPageXMLNew.DEFAULT_MINIMUM_INTERLINE_DISTANCE,
-                    thickness, minimumBaselineThickness, false);
+                    thickness, minimumBaselineThickness, true);
         }
         imageMat = OpenCVWrapper.release(imageMat);
 

--- a/minions/src/main/java/nl/knaw/huc/di/images/minions/MinionLoghiHTRMergePageXML.java
+++ b/minions/src/main/java/nl/knaw/huc/di/images/minions/MinionLoghiHTRMergePageXML.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
 
 public class MinionLoghiHTRMergePageXML extends BaseMinion implements Runnable {
     private static final Logger LOG = LoggerFactory.getLogger(MinionLoghiHTRMergePageXML.class);
+    private static final Pattern HTR_MARKER_TAG_PATTERN = Pattern.compile("<u>|</u>|<s>|</s>|<sub>|</sub>|<sup>|</sup>");
     private final Map<String, String> fileTextLineMap;
     private final Map<String, String> batchMetadataMap;
     private final Consumer<PcGts> pageSaver;
@@ -148,19 +149,18 @@ public class MinionLoghiHTRMergePageXML extends BaseMinion implements Runnable {
             return;
         }
 
+        boolean hasMultipleHtrConfigs = htrConfigs.size() > 1;
         for (TextRegion textRegion : page.getPage().getTextRegions()) {
             for (TextLine textLine : textRegion.getTextLines()) {
-                String text = fileTextLineMap.get(pageFileName + "-" + textLine.getId());
+                String textLineKey = pageFileName + "-" + textLine.getId();
+                String text = fileTextLineMap.get(textLineKey);
                 // If text is empty just continue
                 if (text == null) {
                     continue;
                 }
 
                 // If HTML style tags are included revert it back to the unicode equivalents
-                // Pattern to match any of the specific HTML tags
-                String regex = "<u>|</u>|<s>|</s>|<sub>|</sub>|<sup>|</sup>";
-                Pattern pattern = Pattern.compile(regex);
-                if (pattern.matcher(text).find()){
+                if (HTR_MARKER_TAG_PATTERN.matcher(text).find()){
                     // Found Transformer style input string with HTML tags
                     text = StyledString.applyMarkersWithNestedTags(text);
                 }
@@ -182,19 +182,19 @@ public class MinionLoghiHTRMergePageXML extends BaseMinion implements Runnable {
                 String cleanText = styledString.getCleanText();
 
                 // Get confidence score for text line
-                Double confidence = confidenceMap.get(pageFileName + "-" + textLine.getId());
+                Double confidence = confidenceMap.get(textLineKey);
 
                 // Set TextEquiv elements and confidence score
                 textLine.setTextEquiv(new TextEquiv(confidence, unicodeToAsciiTranslitirator.toAscii(cleanText), cleanText));
                 textLine.setWords(new ArrayList<>());
 
                 // Get batch_metadata for line ID
-                String batchMetadata = batchMetadataMap.get(pageFileName + "-" + textLine.getId());
+                String batchMetadata = batchMetadataMap.get(textLineKey);
 
                 // Set custom userAttribute
                 // Either create simple UserAttribute(name, value) or detailed UserAttribute(name, description, type, value)
                 // Only need to do this if we have more than 1 HTRConfigs
-                if (htrConfigs.size() > 1)
+                if (hasMultipleHtrConfigs)
                     textLine.addUserAttributeToUserDefined(new UserAttribute("htrProcessingStep", batchMetadata));
 
                 // Set custom text attribute

--- a/minions/src/main/java/nl/knaw/huc/di/images/minions/MinionRecalculateReadingOrderNew.java
+++ b/minions/src/main/java/nl/knaw/huc/di/images/minions/MinionRecalculateReadingOrderNew.java
@@ -43,6 +43,22 @@ public class MinionRecalculateReadingOrderNew implements Runnable, AutoCloseable
 
     private final List<String> readingOrderList;
 
+    private static final class TextLineGeometry {
+        private final List<Point> baselinePoints;
+        private final Point start;
+        private final Point end;
+        private final Rect baselineRect;
+        private final Rect coordsRect;
+
+        private TextLineGeometry(TextLine textLine) {
+            this.baselinePoints = StringConverter.stringToPoint(textLine.getBaseline().getPoints());
+            this.start = baselinePoints.get(0);
+            this.end = baselinePoints.get(baselinePoints.size() - 1);
+            this.baselineRect = LayoutProc.getBoundingBox(baselinePoints);
+            this.coordsRect = LayoutProc.getBoundingBox(StringConverter.stringToPoint(textLine.getCoords().getPoints()));
+        }
+    }
+
     public MinionRecalculateReadingOrderNew(String identifier, PcGts page, Consumer<PcGts> pageSaver,
                                             boolean cleanBorders, int borderMargin, boolean asSingleRegion,
                                             double interlineClusteringMultiplier, double dubiousSizeWidthMultiplier,
@@ -207,38 +223,51 @@ public class MinionRecalculateReadingOrderNew implements Runnable, AutoCloseable
             return getPcGtsWithSingleRegion(page, allLines);
         }
 
-        double interlinemedian = LayoutProc.interlineMedian(allLines, 10);
+        List<TextLineGeometry> allLineGeometries = new ArrayList<>(allLines.size());
+        Map<TextLine, TextLineGeometry> geometryByTextLine = new IdentityHashMap<>();
+        for (TextLine textLine : allLines) {
+            TextLineGeometry textLineGeometry = new TextLineGeometry(textLine);
+            allLineGeometries.add(textLineGeometry);
+            geometryByTextLine.put(textLine, textLineGeometry);
+        }
+
+        double interlinemedian = interlineMedian(allLineGeometries, 10);
         LOG.info(id + " interlinemedian: " + interlinemedian);
 
         List<TextLine> linesToRemove = new ArrayList<>();
         page.getPage().getTextRegions().clear();
         if (cleanBorders) {
-            cleanBorders(page, borderMargin, allLines, dubiousSizeWidth, linesToRemove);
+            cleanBorders(page, borderMargin, allLines, dubiousSizeWidth, linesToRemove, geometryByTextLine);
         }
 
-        List<TextLine> removedLines = new ArrayList<>();
+        Set<TextLine> removedLines = Collections.newSetFromMap(new IdentityHashMap<>());
         for (TextLine textLine : allLines) {
             if (removedLines.contains(textLine)) {
                 continue;
             }
+            TextLineGeometry textLineGeometry = geometryByTextLine.get(textLine);
             List<TextLine> cluster = new ArrayList<>();
             cluster.add(textLine);
-            Rect regionPoints = LayoutProc.getBoundingBoxTextLines(cluster);
+            Rect regionPoints = textLineGeometry.coordsRect;
             removedLines.add(textLine);
-            List<TextLine> checkedTextLines = new ArrayList<>();
+            Set<TextLine> checkedTextLines = Collections.newSetFromMap(new IdentityHashMap<>());
 
             boolean newLinesAdded = true;
             while (newLinesAdded) {
                 newLinesAdded = false;
-                ArrayList<TextLine> toCheck = new ArrayList<>(cluster);
-                toCheck.removeAll(checkedTextLines);
+                ArrayList<TextLine> toCheck = new ArrayList<>(cluster.size());
+                for (TextLine clusteredTextLine : cluster) {
+                    if (!checkedTextLines.contains(clusteredTextLine)) {
+                        toCheck.add(clusteredTextLine);
+                    }
+                }
                 for (TextLine mainTextLine : toCheck) {
                     checkedTextLines.add(mainTextLine);
 //                    System.out.println("new mainTextLine: " + stopwatch.elapsed(TimeUnit.MILLISECONDS));
-                    List<Point> mainPoints = StringConverter.stringToPoint(mainTextLine.getBaseline().getPoints());
+                    TextLineGeometry mainTextLineGeometry = geometryByTextLine.get(mainTextLine);
 //                    double mainTextLineOrientation = LayoutProc.getMainAngle(mainPoints);
-                    Point mainTextLineStart = mainPoints.get(0);
-                    Point mainTextLineEnd = mainPoints.get(mainPoints.size() - 1);
+                    Point mainTextLineStart = mainTextLineGeometry.start;
+                    Point mainTextLineEnd = mainTextLineGeometry.end;
 
                     for (TextLine subTextLine : allLines) {
                         if (removedLines.contains(subTextLine)) {
@@ -249,17 +278,17 @@ public class MinionRecalculateReadingOrderNew implements Runnable, AutoCloseable
 //                if (LayoutProc.distance())
 //                && closeby
 //                        System.out.println("new subtextline: " + stopwatch.elapsed(TimeUnit.MILLISECONDS));
-                        List<Point> subPoints = StringConverter.stringToPoint(subTextLine.getBaseline().getPoints());
-                        Point subTextLineStart = subPoints.get(0);
-                        Point subTextLineEnd = subPoints.get(subPoints.size() - 1);
-                        Rect textLineRect = LayoutProc.getBoundingBox(subPoints);
+                        TextLineGeometry subTextLineGeometry = geometryByTextLine.get(subTextLine);
+                        Point subTextLineStart = subTextLineGeometry.start;
+                        Point subTextLineEnd = subTextLineGeometry.end;
+                        Rect textLineRect = subTextLineGeometry.baselineRect;
                         // if textline inside region already
                         if (regionPoints.x< textLineRect.x &&
                                 regionPoints.x + regionPoints.width > textLineRect.x + textLineRect.width &&
                                 regionPoints.y< textLineRect.y &&
                                 regionPoints.y + regionPoints.height > textLineRect.y + textLineRect.height){
                             cluster.add(subTextLine);
-                            regionPoints = LayoutProc.growCluster(regionPoints, subTextLine);
+                            regionPoints = growCluster(regionPoints, subTextLineGeometry.coordsRect);
 
                             removedLines.add(subTextLine);
                             newLinesAdded = true;
@@ -269,7 +298,7 @@ public class MinionRecalculateReadingOrderNew implements Runnable, AutoCloseable
                         double maxDistance = interlinemedian * interlineClusteringMultiplier;
                         if (StringConverter.distance(mainTextLineStart, subTextLineStart) < maxDistance) {
                             cluster.add(subTextLine);
-                            regionPoints = LayoutProc.growCluster(regionPoints, subTextLine);
+                            regionPoints = growCluster(regionPoints, subTextLineGeometry.coordsRect);
                             removedLines.add(subTextLine);
                             newLinesAdded = true;
                         } else {
@@ -281,7 +310,7 @@ public class MinionRecalculateReadingOrderNew implements Runnable, AutoCloseable
                                 // and y-distance is less than interlineClusteringMultiplier * interline
                                 if (Math.abs(averageSubPointY - mainTextLineY) < maxDistance) {
                                     cluster.add(subTextLine);
-                                    regionPoints = LayoutProc.growCluster(regionPoints, subTextLine);
+                                    regionPoints = growCluster(regionPoints, subTextLineGeometry.coordsRect);
                                     removedLines.add(subTextLine);
                                     newLinesAdded = true;
                                 }
@@ -303,9 +332,7 @@ public class MinionRecalculateReadingOrderNew implements Runnable, AutoCloseable
 
             Rect finalRegionPoints = regionPoints;
             cluster.sort(Comparator.comparing(textLine1 ->
-                    StringConverter.distance(new Point(finalRegionPoints.x, finalRegionPoints.y),
-                            new Point(finalRegionPoints.x + (StringConverter.stringToPoint(textLine1.getBaseline().getPoints()).get(0).x - finalRegionPoints.x) / 10,
-                                    StringConverter.stringToPoint(textLine1.getBaseline().getPoints()).get(0).y))));
+                    distanceFromRegionStart(finalRegionPoints, geometryByTextLine.get(textLine1))));
             int counter = 0;
             for (TextLine textLine1 : cluster) {
 //                TODO: maybe use TextLineCustom here instead.
@@ -338,23 +365,30 @@ public class MinionRecalculateReadingOrderNew implements Runnable, AutoCloseable
         return page;
     }
 
+    private static double distanceFromRegionStart(Rect regionPoints, TextLineGeometry textLineGeometry) {
+        Point baselineStart = textLineGeometry.start;
+        return StringConverter.distance(new Point(regionPoints.x, regionPoints.y),
+                new Point(regionPoints.x + (baselineStart.x - regionPoints.x) / 10, baselineStart.y));
+    }
+
     private static String getOldCustom(TextLine textLine1) {
         String oldCustom = textLine1.getCustom();
         if (!Strings.isNullOrEmpty(oldCustom) && oldCustom.contains("readingOrder {index:")){
             // remove old reading order
             String prefix = oldCustom.substring(0, oldCustom.indexOf("readingOrder {index:"));
-            String suffix = oldCustom.split("readingOrder")[1];
-            suffix = suffix.substring(suffix.indexOf("}")+1);
+            String suffix = oldCustom.substring(oldCustom.indexOf("readingOrder"));
+            suffix = suffix.substring(suffix.indexOf("}") + 1);
             oldCustom = prefix + suffix;
         }
         return oldCustom;
     }
 
-    private static void cleanBorders(PcGts page, int borderMargin, List<TextLine> allLines, double dubiousSizeWidth, List<TextLine> linesToRemove) {
+    private static void cleanBorders(PcGts page, int borderMargin, List<TextLine> allLines, double dubiousSizeWidth,
+                                     List<TextLine> linesToRemove, Map<TextLine, TextLineGeometry> geometryByTextLine) {
         for (TextLine textLine : allLines) {
-            List<Point> points = StringConverter.stringToPoint(textLine.getBaseline().getPoints());
-            Point textLineStart = points.get(0);
-            Point textLineEnd = points.get(points.size() - 1);
+            TextLineGeometry textLineGeometry = geometryByTextLine.get(textLine);
+            Point textLineStart = textLineGeometry.start;
+            Point textLineEnd = textLineGeometry.end;
             if (Math.abs(textLineEnd.x - page.getPage().getImageWidth()) < borderMargin) {
                 if (StringConverter.distance(textLineStart, textLineEnd) < dubiousSizeWidth) {
                     linesToRemove.add(textLine);
@@ -368,6 +402,51 @@ public class MinionRecalculateReadingOrderNew implements Runnable, AutoCloseable
 
         }
         allLines.removeAll(linesToRemove);
+    }
+
+    private static double interlineMedian(List<TextLineGeometry> textLineGeometries, double minValue) {
+        double interlineDistance = interlineMedian(textLineGeometries);
+        return Math.max(interlineDistance, minValue);
+    }
+
+    private static double interlineMedian(List<TextLineGeometry> textLineGeometries) {
+        if (textLineGeometries.isEmpty()) {
+            return 0;
+        }
+
+        List<Point> allPoints = new ArrayList<>();
+        for (TextLineGeometry textLineGeometry : textLineGeometries) {
+            allPoints.addAll(textLineGeometry.baselinePoints);
+        }
+
+        ArrayList<Double> distances = new ArrayList<>(textLineGeometries.size());
+        for (TextLineGeometry textLineGeometry : textLineGeometries) {
+            ArrayList<Point> otherPoints = new ArrayList<>(allPoints);
+            otherPoints.removeAll(textLineGeometry.baselinePoints);
+            double distance = LayoutProc.findClosestDistance(otherPoints, textLineGeometry.baselinePoints);
+            distances.add(distance);
+        }
+        return median(distances);
+    }
+
+    private static double median(List<Double> values) {
+        if (values.isEmpty()) {
+            return 0;
+        }
+        values.sort(Double::compareTo);
+        int size = values.size();
+        if (size % 2 == 0) {
+            return (values.get((size / 2) - 1) + values.get(size / 2)) / 2.0;
+        }
+        return values.get(size / 2);
+    }
+
+    private static Rect growCluster(Rect region, Rect textLineBoundingBox) {
+        int xStart = Math.min(region.x, textLineBoundingBox.x);
+        int yStart = Math.min(region.y, textLineBoundingBox.y);
+        int xStop = Math.max(region.x + region.width, textLineBoundingBox.x + textLineBoundingBox.width);
+        int yStop = Math.max(region.y + region.height, textLineBoundingBox.y + textLineBoundingBox.height);
+        return new Rect(xStart, yStart, xStop - xStart, yStop - yStart);
     }
 
     private static PcGts getPcGtsWithSingleRegion(PcGts page, List<TextLine> allLines) {

--- a/minions/src/test/java/nl/knaw/huc/di/images/minions/BaselinesMapperTest.java
+++ b/minions/src/test/java/nl/knaw/huc/di/images/minions/BaselinesMapperTest.java
@@ -66,8 +66,8 @@ class BaselinesMapperTest {
     @Test
     public void returnsMappingWithoutNewLinesThatMatchMultipleOldLines() {
         final List<TextLine> newLines = new ArrayList<>();
-        newLines.add(createTextLineWithIdAndBaselineCoords("newId", "0,20, 400,20"));
-        final List<TextLine> oldLines = List.of(createTextLineWithIdAndBaselineCoords("oldId1", "0,20, 200,20"), createTextLineWithIdAndBaselineCoords("oldId2", "200,20, 400,20"));
+        newLines.add(createTextLineWithIdAndBaselineCoords("newId", "0,20 400,20"));
+        final List<TextLine> oldLines = List.of(createTextLineWithIdAndBaselineCoords("oldId1", "0,20 200,20"), createTextLineWithIdAndBaselineCoords("oldId2", "200,20 400,20"));
 
         final Map<String, String> newLinesToOldLinesMap = BaselinesMapper.mapNewLinesToOldLines(newLines, oldLines, new Size(500, 500));
 
@@ -76,8 +76,8 @@ class BaselinesMapperTest {
 
     @Test
     public void returnsMappingWithoutNewLinesThatMatchTheSameOldLine() {
-        final List<TextLine> newLines = List.of(createTextLineWithIdAndBaselineCoords("newId1", "0,20, 200,20"), createTextLineWithIdAndBaselineCoords("newId2", "200,20, 400,20"));
-        final List<TextLine> oldLines = List.of(createTextLineWithIdAndBaselineCoords("oldId", "0,20, 400,20"));
+        final List<TextLine> newLines = List.of(createTextLineWithIdAndBaselineCoords("newId1", "0,20 200,20"), createTextLineWithIdAndBaselineCoords("newId2", "200,20 400,20"));
+        final List<TextLine> oldLines = List.of(createTextLineWithIdAndBaselineCoords("oldId", "0,20 400,20"));
 
         final Map<String, String> newLinesToOldLinesMap = BaselinesMapper.mapNewLinesToOldLines(newLines, oldLines, new Size(500, 500));
 

--- a/minions/src/test/java/nl/knaw/huc/di/images/minions/MergeBenchmark.java
+++ b/minions/src/test/java/nl/knaw/huc/di/images/minions/MergeBenchmark.java
@@ -1,12 +1,10 @@
-import nl.knaw.huc.di.images.layoutanalyzer.layoutlib.LayoutProc;
-import nl.knaw.huc.di.images.layoutanalyzer.layoutlib.OpenCVWrapper;
+package nl.knaw.huc.di.images.minions;
+
+import nl.knaw.huc.di.images.layoutds.models.HTRConfig;
 import nl.knaw.huc.di.images.layoutds.models.Page.PcGts;
-import nl.knaw.huc.di.images.layoutds.models.Page.TextLine;
 import nl.knaw.huc.di.images.layoutds.models.Page.TextRegion;
 import nl.knaw.huc.di.images.pagexmlutils.PageUtils;
 import org.opencv.core.Core;
-import org.opencv.core.Mat;
-import org.opencv.imgcodecs.Imgcodecs;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -19,55 +17,54 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
-public class RecalculateContoursBenchmark {
+public class MergeBenchmark {
     private static final class Config {
-        private Path imageDir = Paths.get("/data/ijsberg/full/train");
-        private Path xmlDir = Paths.get("/data/ijsberg/full/train/page");
-        private Path csv = Paths.get("/tmp/recalculate-contours-benchmark.csv");
-        private String label = "benchmark";
-        private int limit = 20;
-        private int warmup = 1;
-        private int runs = 3;
-        private double scaleDownFactor = 4;
-        private int minimumInterlineDistance = 35;
-        private int thickness = 10;
-        private int minimumBaselineThickness = 1;
-        private boolean ignoreBroken = true;
-        private boolean ignoreXmlErrors = false;
-        private boolean suppressStderr = true;
-        private Path dumpContours = null;
+        Path imageDir = Paths.get("/data/ijsberg/full/train");
+        Path xmlDir = Paths.get("/data/ijsberg/full/train/page");
+        Path linesDir = Paths.get("/data/ijsberg/lines/train");
+        Path csv = Paths.get("/tmp/merge-benchmark.csv");
+        String label = "benchmark";
+        int limit = 20;
+        int warmup = 1;
+        int runs = 3;
+        double pinnedConfidence = 0.95;
+        boolean ignoreXmlErrors = false;
+        boolean suppressStderr = true;
     }
 
     private static final class Pair {
-        private final String stem;
-        private final Path image;
-        private final Path xml;
+        final String stem;
+        final Path xml;
+        final Path lineDir;
 
-        private Pair(String stem, Path image, Path xml) {
+        Pair(String stem, Path xml, Path lineDir) {
             this.stem = stem;
-            this.image = image;
             this.xml = xml;
+            this.lineDir = lineDir;
         }
     }
 
     private static final class Measurement {
-        private final String stem;
-        private final int run;
-        private final long elapsedNanos;
-        private final int width;
-        private final int height;
-        private final int lines;
+        final String stem;
+        final int run;
+        final long elapsedNanos;
+        final int lines;
+        final int matched;
 
-        private Measurement(String stem, int run, long elapsedNanos, int width, int height, int lines) {
+        Measurement(String stem, int run, long elapsedNanos, int lines, int matched) {
             this.stem = stem;
             this.run = run;
             this.elapsedNanos = elapsedNanos;
-            this.width = width;
-            this.height = height;
             this.lines = lines;
+            this.matched = matched;
         }
     }
 
@@ -78,7 +75,8 @@ public class RecalculateContoursBenchmark {
 
         List<Pair> pairs = selectPairs(findPairs(config), config.limit);
         if (pairs.isEmpty()) {
-            throw new IllegalArgumentException("No image/xml pairs found in " + config.imageDir + " and " + config.xmlDir);
+            throw new IllegalArgumentException(
+                    "No xml/lines pairs found. xmlDir=" + config.xmlDir + " linesDir=" + config.linesDir);
         }
 
         if (config.csv.getParent() != null) {
@@ -87,34 +85,18 @@ public class RecalculateContoursBenchmark {
 
         List<Measurement> measurements = new ArrayList<>();
         int failures = 0;
-        BufferedWriter dumpWriter = null;
-        if (config.dumpContours != null) {
-            if (config.dumpContours.getParent() != null) {
-                Files.createDirectories(config.dumpContours.getParent());
-            }
-            dumpWriter = Files.newBufferedWriter(config.dumpContours, StandardCharsets.UTF_8);
-            dumpWriter.write("stem\tlineId\tcontour");
-            dumpWriter.newLine();
-        }
         try (BufferedWriter writer = Files.newBufferedWriter(config.csv, StandardCharsets.UTF_8)) {
-            writer.write("label,stem,run,elapsed_ms,width,height,lines,status,error");
+            writer.write("label,stem,run,elapsed_ms,lines,matched,status,error");
             writer.newLine();
 
             for (int i = 0; i < config.warmup; i++) {
-                failures += executeRun(config, pairs, -1, writer, null, null);
+                failures += executeRun(config, pairs, -1, writer, null);
                 System.gc();
             }
 
             for (int run = 1; run <= config.runs; run++) {
-                // Only dump contours during run 1 to keep the dump deterministic
-                // and avoid quadrupling the file size.
-                BufferedWriter dumpForRun = run == 1 ? dumpWriter : null;
-                failures += executeRun(config, pairs, run, writer, measurements, dumpForRun);
+                failures += executeRun(config, pairs, run, writer, measurements);
                 System.gc();
-            }
-        } finally {
-            if (dumpWriter != null) {
-                dumpWriter.close();
             }
         }
 
@@ -144,32 +126,28 @@ public class RecalculateContoursBenchmark {
     }
 
     private static int executeRun(Config config, List<Pair> pairs, int run, BufferedWriter writer,
-                                  List<Measurement> measurements, BufferedWriter dumpWriter) throws IOException {
+                                  List<Measurement> measurements) throws IOException {
         int failures = 0;
         for (Pair pair : pairs) {
-            Mat image = null;
             try {
                 String xml = Files.readString(pair.xml);
-                PcGts page = PageUtils.readPageFromString(xml, config.ignoreXmlErrors);
-                if (page == null) {
+                PcGts probePage = PageUtils.readPageFromString(xml, config.ignoreXmlErrors);
+                if (probePage == null) {
                     throw new IllegalStateException("PAGE parse returned null");
                 }
+                int lines = countLines(probePage);
 
-                image = OpenCVWrapper.imread(pair.image.toString(), Imgcodecs.IMREAD_COLOR);
-                if (image.empty()) {
-                    throw new IllegalStateException("Image could not be read");
-                }
-                int lines = countLines(page);
+                Map<String, String> fileTextLineMap = new HashMap<>();
+                Map<String, Double> confidenceMap = new HashMap<>();
+                Map<String, String> metadataMap = new HashMap<>();
+                int matched = buildResults(config, pair, fileTextLineMap, confidenceMap, metadataMap);
 
-                long elapsed = measureRecalculate(config, pair, image, page);
+                long elapsed = measureMerge(config, pair, fileTextLineMap, confidenceMap, metadataMap);
 
                 if (run > 0) {
-                    Measurement measurement = new Measurement(pair.stem, run, elapsed, image.width(), image.height(), lines);
+                    Measurement measurement = new Measurement(pair.stem, run, elapsed, lines, matched);
                     measurements.add(measurement);
                     writeCsv(writer, config.label, measurement, "ok", "");
-                    if (dumpWriter != null) {
-                        dumpContours(dumpWriter, pair.stem, page);
-                    }
                 }
             } catch (Exception exception) {
                 failures++;
@@ -179,20 +157,42 @@ public class RecalculateContoursBenchmark {
                     writer.write(csv(pair.stem));
                     writer.write(",");
                     writer.write(Integer.toString(run));
-                    writer.write(",,,,,error,");
+                    writer.write(",,,error,");
                     writer.write(csv(exception.getClass().getSimpleName() + ": " + exception.getMessage()));
                     writer.newLine();
-                }
-            } finally {
-                if (image != null && image.dataAddr() != 0) {
-                    image = OpenCVWrapper.release(image);
                 }
             }
         }
         return failures;
     }
 
-    private static long measureRecalculate(Config config, Pair pair, Mat image, PcGts page) {
+    private static int buildResults(Config config, Pair pair,
+                                     Map<String, String> fileTextLineMap,
+                                     Map<String, Double> confidenceMap,
+                                     Map<String, String> metadataMap) throws IOException {
+        int count = 0;
+        try (Stream<Path> stream = Files.list(pair.lineDir)) {
+            List<Path> txtFiles = stream
+                    .filter(p -> p.getFileName().toString().endsWith(".txt"))
+                    .sorted()
+                    .toList();
+            for (Path txt : txtFiles) {
+                String filename = txt.getFileName().toString();
+                String key = filename.substring(0, filename.length() - ".txt".length());
+                String text = Files.readString(txt, StandardCharsets.UTF_8).strip();
+                fileTextLineMap.put(key, text);
+                confidenceMap.put(key, config.pinnedConfidence);
+                metadataMap.put(key, "[]");
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static long measureMerge(Config config, Pair pair,
+                                     Map<String, String> fileTextLineMap,
+                                     Map<String, Double> confidenceMap,
+                                     Map<String, String> metadataMap) {
         PrintStream originalErr = System.err;
         PrintStream mutedErr = null;
         if (config.suppressStderr) {
@@ -200,17 +200,32 @@ public class RecalculateContoursBenchmark {
             System.setErr(mutedErr);
         }
 
+        Supplier<PcGts> pageSupplier = () -> {
+            try {
+                String xml = Files.readString(pair.xml);
+                return PageUtils.readPageFromString(xml, config.ignoreXmlErrors);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        HTRConfig htrConfig = new HTRConfig();
+        MinionLoghiHTRMergePageXML minion = new MinionLoghiHTRMergePageXML(
+                pair.stem,
+                pageSupplier,
+                htrConfig,
+                fileTextLineMap,
+                metadataMap,
+                confidenceMap,
+                /* pageSaver */ p -> {},
+                /* pageFileName */ pair.stem,
+                /* comment */ null,
+                /* gitHash */ null,
+                Optional.empty());
+
         long start = System.nanoTime();
         try {
-            LayoutProc.recalculateTextLineContoursFromBaselines(
-                    pair.stem,
-                    image,
-                    page,
-                    config.scaleDownFactor,
-                    config.minimumInterlineDistance,
-                    config.thickness,
-                    config.minimumBaselineThickness,
-                    config.ignoreBroken);
+            minion.run();
             return System.nanoTime() - start;
         } finally {
             if (mutedErr != null) {
@@ -230,11 +245,9 @@ public class RecalculateContoursBenchmark {
         writer.write(",");
         writer.write(String.format(Locale.ROOT, "%.3f", measurement.elapsedNanos / 1_000_000d));
         writer.write(",");
-        writer.write(Integer.toString(measurement.width));
-        writer.write(",");
-        writer.write(Integer.toString(measurement.height));
-        writer.write(",");
         writer.write(Integer.toString(measurement.lines));
+        writer.write(",");
+        writer.write(Integer.toString(measurement.matched));
         writer.write(",");
         writer.write(csv(status));
         writer.write(",");
@@ -250,8 +263,9 @@ public class RecalculateContoursBenchmark {
                     .forEach(image -> {
                         String stem = stem(image.getFileName().toString());
                         Path xml = config.xmlDir.resolve(stem + ".xml");
-                        if (Files.isRegularFile(xml)) {
-                            pairs.add(new Pair(stem, image, xml));
+                        Path lineDir = config.linesDir.resolve(stem);
+                        if (Files.isRegularFile(xml) && Files.isDirectory(lineDir)) {
+                            pairs.add(new Pair(stem, xml, lineDir));
                         }
                     });
         }
@@ -262,33 +276,12 @@ public class RecalculateContoursBenchmark {
         if (limit <= 0 || limit >= pairs.size()) {
             return pairs;
         }
-
         List<Pair> selected = new ArrayList<>(limit);
         double step = (double) pairs.size() / (double) limit;
         for (int i = 0; i < limit; i++) {
             selected.add(pairs.get((int) Math.floor(i * step)));
         }
         return selected;
-    }
-
-    private static void dumpContours(BufferedWriter writer, String stem, PcGts page) throws IOException {
-        // Stable, sortable per-line dump for equivalence checking across optimization
-        // runs. Format: <stem>\t<lineId>\t<x1,y1 x2,y2 ...>. Lines emitted in
-        // (region order, line order) — same as the in-memory page traversal.
-        for (TextRegion textRegion : page.getPage().getTextRegions()) {
-            for (TextLine textLine : textRegion.getTextLines()) {
-                String coords = "";
-                if (textLine.getCoords() != null && textLine.getCoords().getPoints() != null) {
-                    coords = textLine.getCoords().getPoints();
-                }
-                writer.write(stem);
-                writer.write('\t');
-                writer.write(textLine.getId() == null ? "" : textLine.getId());
-                writer.write('\t');
-                writer.write(coords);
-                writer.newLine();
-            }
-        }
     }
 
     private static int countLines(PcGts page) {
@@ -349,6 +342,9 @@ public class RecalculateContoursBenchmark {
                 case "--xml-dir":
                     config.xmlDir = Paths.get(value(args, ++i, arg));
                     break;
+                case "--lines-dir":
+                    config.linesDir = Paths.get(value(args, ++i, arg));
+                    break;
                 case "--csv":
                     config.csv = Paths.get(value(args, ++i, arg));
                     break;
@@ -364,29 +360,14 @@ public class RecalculateContoursBenchmark {
                 case "--runs":
                     config.runs = Integer.parseInt(value(args, ++i, arg));
                     break;
-                case "--scale":
-                    config.scaleDownFactor = Double.parseDouble(value(args, ++i, arg));
-                    break;
-                case "--minimum-interline-distance":
-                    config.minimumInterlineDistance = Integer.parseInt(value(args, ++i, arg));
-                    break;
-                case "--thickness":
-                    config.thickness = Integer.parseInt(value(args, ++i, arg));
-                    break;
-                case "--minimum-baseline-thickness":
-                    config.minimumBaselineThickness = Integer.parseInt(value(args, ++i, arg));
-                    break;
-                case "--ignore-broken":
-                    config.ignoreBroken = Boolean.parseBoolean(value(args, ++i, arg));
+                case "--pinned-confidence":
+                    config.pinnedConfidence = Double.parseDouble(value(args, ++i, arg));
                     break;
                 case "--ignore-xml-errors":
                     config.ignoreXmlErrors = Boolean.parseBoolean(value(args, ++i, arg));
                     break;
                 case "--suppress-stderr":
                     config.suppressStderr = Boolean.parseBoolean(value(args, ++i, arg));
-                    break;
-                case "--dump-contours":
-                    config.dumpContours = Paths.get(value(args, ++i, arg));
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown argument: " + arg);

--- a/minions/src/test/java/nl/knaw/huc/di/images/minions/MergeBenchmarkTest.java
+++ b/minions/src/test/java/nl/knaw/huc/di/images/minions/MergeBenchmarkTest.java
@@ -1,10 +1,12 @@
+package nl.knaw.huc.di.images.minions;
+
 import org.junit.Assume;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class RecalculateContoursBenchmarkTest {
+public class MergeBenchmarkTest {
     @Test
     public void runBenchmark() throws Exception {
         Assume.assumeTrue(Boolean.getBoolean("benchmark.enabled"));
@@ -12,21 +14,17 @@ public class RecalculateContoursBenchmarkTest {
         List<String> args = new ArrayList<>();
         add(args, "--image-dir", "benchmark.imageDir");
         add(args, "--xml-dir", "benchmark.xmlDir");
+        add(args, "--lines-dir", "benchmark.linesDir");
         add(args, "--csv", "benchmark.csv");
         add(args, "--label", "benchmark.label");
         add(args, "--limit", "benchmark.limit");
         add(args, "--warmup", "benchmark.warmup");
         add(args, "--runs", "benchmark.runs");
-        add(args, "--scale", "benchmark.scale");
-        add(args, "--minimum-interline-distance", "benchmark.minimumInterlineDistance");
-        add(args, "--thickness", "benchmark.thickness");
-        add(args, "--minimum-baseline-thickness", "benchmark.minimumBaselineThickness");
-        add(args, "--ignore-broken", "benchmark.ignoreBroken");
+        add(args, "--pinned-confidence", "benchmark.pinnedConfidence");
         add(args, "--ignore-xml-errors", "benchmark.ignoreXmlErrors");
         add(args, "--suppress-stderr", "benchmark.suppressStderr");
-        add(args, "--dump-contours", "benchmark.dumpContours");
 
-        RecalculateContoursBenchmark.main(args.toArray(new String[0]));
+        MergeBenchmark.main(args.toArray(new String[0]));
     }
 
     private static void add(List<String> args, String flag, String property) {

--- a/minions/src/test/java/nl/knaw/huc/di/images/minions/MinionFixPageXMLTest.java
+++ b/minions/src/test/java/nl/knaw/huc/di/images/minions/MinionFixPageXMLTest.java
@@ -18,8 +18,8 @@ class MinionFixPageXMLTest {
 
     private final String sampleXml2013 = "<PcGts xmlns=\"http://schema.primaresearch.org/PAGE/gts/pagecontent/2013-07-15\">" +
             "<Page>" +
-            "<TextRegion>" +
-            "<TextLine>" +
+            "<TextRegion id=\"region_1\">" +
+            "<TextLine id=\"line_1\">" +
             "<TextEquiv>Sample Text</TextEquiv>" +
             "<Word>Sample Word</Word>" +
             "</TextLine>" +
@@ -29,8 +29,8 @@ class MinionFixPageXMLTest {
 
     private final String sampleXml2019 = "<PcGts xmlns=\"http://schema.primaresearch.org/PAGE/gts/pagecontent/2019-07-15\">" +
             "<Page>" +
-            "<TextRegion>" +
-            "<TextLine>" +
+            "<TextRegion id=\"region_1\">" +
+            "<TextLine id=\"line_1\">" +
             "<TextEquiv>Sample Text</TextEquiv>" +
             "<Word>Sample Word</Word>" +
             "</TextLine>" +

--- a/minions/src/test/java/nl/knaw/huc/di/images/minions/ReadingOrderBenchmark.java
+++ b/minions/src/test/java/nl/knaw/huc/di/images/minions/ReadingOrderBenchmark.java
@@ -1,12 +1,9 @@
-import nl.knaw.huc.di.images.layoutanalyzer.layoutlib.LayoutProc;
-import nl.knaw.huc.di.images.layoutanalyzer.layoutlib.OpenCVWrapper;
+package nl.knaw.huc.di.images.minions;
+
 import nl.knaw.huc.di.images.layoutds.models.Page.PcGts;
-import nl.knaw.huc.di.images.layoutds.models.Page.TextLine;
 import nl.knaw.huc.di.images.layoutds.models.Page.TextRegion;
 import nl.knaw.huc.di.images.pagexmlutils.PageUtils;
 import org.opencv.core.Core;
-import org.opencv.core.Mat;
-import org.opencv.imgcodecs.Imgcodecs;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -21,52 +18,50 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 
-public class RecalculateContoursBenchmark {
+public class ReadingOrderBenchmark {
     private static final class Config {
-        private Path imageDir = Paths.get("/data/ijsberg/full/train");
-        private Path xmlDir = Paths.get("/data/ijsberg/full/train/page");
-        private Path csv = Paths.get("/tmp/recalculate-contours-benchmark.csv");
-        private String label = "benchmark";
-        private int limit = 20;
-        private int warmup = 1;
-        private int runs = 3;
-        private double scaleDownFactor = 4;
-        private int minimumInterlineDistance = 35;
-        private int thickness = 10;
-        private int minimumBaselineThickness = 1;
-        private boolean ignoreBroken = true;
-        private boolean ignoreXmlErrors = false;
-        private boolean suppressStderr = true;
-        private Path dumpContours = null;
+        Path imageDir = Paths.get("/data/ijsberg/full/train");
+        Path xmlDir = Paths.get("/data/ijsberg/full/train/page");
+        Path csv = Paths.get("/tmp/reading-order-benchmark.csv");
+        String label = "benchmark";
+        int limit = 20;
+        int warmup = 1;
+        int runs = 3;
+        boolean cleanBorders = false;
+        int borderMargin = 200;
+        boolean asSingleRegion = false;
+        double interlineClusteringMultiplier = 1.5;
+        double dubiousSizeWidthMultiplier = 0.05;
+        boolean ignoreXmlErrors = false;
+        boolean suppressStderr = true;
     }
 
     private static final class Pair {
-        private final String stem;
-        private final Path image;
-        private final Path xml;
+        final String stem;
+        final Path xml;
 
-        private Pair(String stem, Path image, Path xml) {
+        Pair(String stem, Path xml) {
             this.stem = stem;
-            this.image = image;
             this.xml = xml;
         }
     }
 
     private static final class Measurement {
-        private final String stem;
-        private final int run;
-        private final long elapsedNanos;
-        private final int width;
-        private final int height;
-        private final int lines;
+        final String stem;
+        final int run;
+        final long elapsedNanos;
+        final int regionsBefore;
+        final int regionsAfter;
+        final int lines;
 
-        private Measurement(String stem, int run, long elapsedNanos, int width, int height, int lines) {
+        Measurement(String stem, int run, long elapsedNanos, int regionsBefore, int regionsAfter, int lines) {
             this.stem = stem;
             this.run = run;
             this.elapsedNanos = elapsedNanos;
-            this.width = width;
-            this.height = height;
+            this.regionsBefore = regionsBefore;
+            this.regionsAfter = regionsAfter;
             this.lines = lines;
         }
     }
@@ -78,7 +73,7 @@ public class RecalculateContoursBenchmark {
 
         List<Pair> pairs = selectPairs(findPairs(config), config.limit);
         if (pairs.isEmpty()) {
-            throw new IllegalArgumentException("No image/xml pairs found in " + config.imageDir + " and " + config.xmlDir);
+            throw new IllegalArgumentException("No xml pairs found in " + config.xmlDir);
         }
 
         if (config.csv.getParent() != null) {
@@ -87,34 +82,18 @@ public class RecalculateContoursBenchmark {
 
         List<Measurement> measurements = new ArrayList<>();
         int failures = 0;
-        BufferedWriter dumpWriter = null;
-        if (config.dumpContours != null) {
-            if (config.dumpContours.getParent() != null) {
-                Files.createDirectories(config.dumpContours.getParent());
-            }
-            dumpWriter = Files.newBufferedWriter(config.dumpContours, StandardCharsets.UTF_8);
-            dumpWriter.write("stem\tlineId\tcontour");
-            dumpWriter.newLine();
-        }
         try (BufferedWriter writer = Files.newBufferedWriter(config.csv, StandardCharsets.UTF_8)) {
-            writer.write("label,stem,run,elapsed_ms,width,height,lines,status,error");
+            writer.write("label,stem,run,elapsed_ms,regions_before,regions_after,lines,status,error");
             writer.newLine();
 
             for (int i = 0; i < config.warmup; i++) {
-                failures += executeRun(config, pairs, -1, writer, null, null);
+                failures += executeRun(config, pairs, -1, writer, null);
                 System.gc();
             }
 
             for (int run = 1; run <= config.runs; run++) {
-                // Only dump contours during run 1 to keep the dump deterministic
-                // and avoid quadrupling the file size.
-                BufferedWriter dumpForRun = run == 1 ? dumpWriter : null;
-                failures += executeRun(config, pairs, run, writer, measurements, dumpForRun);
+                failures += executeRun(config, pairs, run, writer, measurements);
                 System.gc();
-            }
-        } finally {
-            if (dumpWriter != null) {
-                dumpWriter.close();
             }
         }
 
@@ -144,32 +123,26 @@ public class RecalculateContoursBenchmark {
     }
 
     private static int executeRun(Config config, List<Pair> pairs, int run, BufferedWriter writer,
-                                  List<Measurement> measurements, BufferedWriter dumpWriter) throws IOException {
+                                  List<Measurement> measurements) throws IOException {
         int failures = 0;
         for (Pair pair : pairs) {
-            Mat image = null;
             try {
                 String xml = Files.readString(pair.xml);
                 PcGts page = PageUtils.readPageFromString(xml, config.ignoreXmlErrors);
                 if (page == null) {
                     throw new IllegalStateException("PAGE parse returned null");
                 }
-
-                image = OpenCVWrapper.imread(pair.image.toString(), Imgcodecs.IMREAD_COLOR);
-                if (image.empty()) {
-                    throw new IllegalStateException("Image could not be read");
-                }
+                int regionsBefore = page.getPage().getTextRegions().size();
                 int lines = countLines(page);
 
-                long elapsed = measureRecalculate(config, pair, image, page);
+                long elapsed = measureReadingOrder(config, pair, page);
+
+                int regionsAfter = page.getPage().getTextRegions().size();
 
                 if (run > 0) {
-                    Measurement measurement = new Measurement(pair.stem, run, elapsed, image.width(), image.height(), lines);
+                    Measurement measurement = new Measurement(pair.stem, run, elapsed, regionsBefore, regionsAfter, lines);
                     measurements.add(measurement);
                     writeCsv(writer, config.label, measurement, "ok", "");
-                    if (dumpWriter != null) {
-                        dumpContours(dumpWriter, pair.stem, page);
-                    }
                 }
             } catch (Exception exception) {
                 failures++;
@@ -183,16 +156,12 @@ public class RecalculateContoursBenchmark {
                     writer.write(csv(exception.getClass().getSimpleName() + ": " + exception.getMessage()));
                     writer.newLine();
                 }
-            } finally {
-                if (image != null && image.dataAddr() != 0) {
-                    image = OpenCVWrapper.release(image);
-                }
             }
         }
         return failures;
     }
 
-    private static long measureRecalculate(Config config, Pair pair, Mat image, PcGts page) {
+    private static long measureReadingOrder(Config config, Pair pair, PcGts page) {
         PrintStream originalErr = System.err;
         PrintStream mutedErr = null;
         if (config.suppressStderr) {
@@ -200,19 +169,31 @@ public class RecalculateContoursBenchmark {
             System.setErr(mutedErr);
         }
 
+        MinionRecalculateReadingOrderNew minion = new MinionRecalculateReadingOrderNew(
+                pair.stem,
+                page,
+                p -> {},
+                config.cleanBorders,
+                config.borderMargin,
+                config.asSingleRegion,
+                config.interlineClusteringMultiplier,
+                config.dubiousSizeWidthMultiplier,
+                null,
+                null,
+                Optional.empty());
+
+        List<String> readingOrderList = new ArrayList<>();
+        readingOrderList.add(null);
+
         long start = System.nanoTime();
         try {
-            LayoutProc.recalculateTextLineContoursFromBaselines(
-                    pair.stem,
-                    image,
-                    page,
-                    config.scaleDownFactor,
-                    config.minimumInterlineDistance,
-                    config.thickness,
-                    config.minimumBaselineThickness,
-                    config.ignoreBroken);
+            minion.runPage(pair.stem, page, config.cleanBorders, config.borderMargin, config.asSingleRegion, readingOrderList);
             return System.nanoTime() - start;
         } finally {
+            try {
+                minion.close();
+            } catch (Exception ignored) {
+            }
             if (mutedErr != null) {
                 System.setErr(originalErr);
                 mutedErr.close();
@@ -230,9 +211,9 @@ public class RecalculateContoursBenchmark {
         writer.write(",");
         writer.write(String.format(Locale.ROOT, "%.3f", measurement.elapsedNanos / 1_000_000d));
         writer.write(",");
-        writer.write(Integer.toString(measurement.width));
+        writer.write(Integer.toString(measurement.regionsBefore));
         writer.write(",");
-        writer.write(Integer.toString(measurement.height));
+        writer.write(Integer.toString(measurement.regionsAfter));
         writer.write(",");
         writer.write(Integer.toString(measurement.lines));
         writer.write(",");
@@ -251,7 +232,7 @@ public class RecalculateContoursBenchmark {
                         String stem = stem(image.getFileName().toString());
                         Path xml = config.xmlDir.resolve(stem + ".xml");
                         if (Files.isRegularFile(xml)) {
-                            pairs.add(new Pair(stem, image, xml));
+                            pairs.add(new Pair(stem, xml));
                         }
                     });
         }
@@ -262,33 +243,12 @@ public class RecalculateContoursBenchmark {
         if (limit <= 0 || limit >= pairs.size()) {
             return pairs;
         }
-
         List<Pair> selected = new ArrayList<>(limit);
         double step = (double) pairs.size() / (double) limit;
         for (int i = 0; i < limit; i++) {
             selected.add(pairs.get((int) Math.floor(i * step)));
         }
         return selected;
-    }
-
-    private static void dumpContours(BufferedWriter writer, String stem, PcGts page) throws IOException {
-        // Stable, sortable per-line dump for equivalence checking across optimization
-        // runs. Format: <stem>\t<lineId>\t<x1,y1 x2,y2 ...>. Lines emitted in
-        // (region order, line order) — same as the in-memory page traversal.
-        for (TextRegion textRegion : page.getPage().getTextRegions()) {
-            for (TextLine textLine : textRegion.getTextLines()) {
-                String coords = "";
-                if (textLine.getCoords() != null && textLine.getCoords().getPoints() != null) {
-                    coords = textLine.getCoords().getPoints();
-                }
-                writer.write(stem);
-                writer.write('\t');
-                writer.write(textLine.getId() == null ? "" : textLine.getId());
-                writer.write('\t');
-                writer.write(coords);
-                writer.newLine();
-            }
-        }
     }
 
     private static int countLines(PcGts page) {
@@ -364,29 +324,26 @@ public class RecalculateContoursBenchmark {
                 case "--runs":
                     config.runs = Integer.parseInt(value(args, ++i, arg));
                     break;
-                case "--scale":
-                    config.scaleDownFactor = Double.parseDouble(value(args, ++i, arg));
+                case "--clean-borders":
+                    config.cleanBorders = Boolean.parseBoolean(value(args, ++i, arg));
                     break;
-                case "--minimum-interline-distance":
-                    config.minimumInterlineDistance = Integer.parseInt(value(args, ++i, arg));
+                case "--border-margin":
+                    config.borderMargin = Integer.parseInt(value(args, ++i, arg));
                     break;
-                case "--thickness":
-                    config.thickness = Integer.parseInt(value(args, ++i, arg));
+                case "--as-single-region":
+                    config.asSingleRegion = Boolean.parseBoolean(value(args, ++i, arg));
                     break;
-                case "--minimum-baseline-thickness":
-                    config.minimumBaselineThickness = Integer.parseInt(value(args, ++i, arg));
+                case "--interline-clustering-multiplier":
+                    config.interlineClusteringMultiplier = Double.parseDouble(value(args, ++i, arg));
                     break;
-                case "--ignore-broken":
-                    config.ignoreBroken = Boolean.parseBoolean(value(args, ++i, arg));
+                case "--dubious-size-width-multiplier":
+                    config.dubiousSizeWidthMultiplier = Double.parseDouble(value(args, ++i, arg));
                     break;
                 case "--ignore-xml-errors":
                     config.ignoreXmlErrors = Boolean.parseBoolean(value(args, ++i, arg));
                     break;
                 case "--suppress-stderr":
                     config.suppressStderr = Boolean.parseBoolean(value(args, ++i, arg));
-                    break;
-                case "--dump-contours":
-                    config.dumpContours = Paths.get(value(args, ++i, arg));
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown argument: " + arg);

--- a/minions/src/test/java/nl/knaw/huc/di/images/minions/ReadingOrderBenchmarkTest.java
+++ b/minions/src/test/java/nl/knaw/huc/di/images/minions/ReadingOrderBenchmarkTest.java
@@ -1,10 +1,12 @@
+package nl.knaw.huc.di.images.minions;
+
 import org.junit.Assume;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class RecalculateContoursBenchmarkTest {
+public class ReadingOrderBenchmarkTest {
     @Test
     public void runBenchmark() throws Exception {
         Assume.assumeTrue(Boolean.getBoolean("benchmark.enabled"));
@@ -17,16 +19,15 @@ public class RecalculateContoursBenchmarkTest {
         add(args, "--limit", "benchmark.limit");
         add(args, "--warmup", "benchmark.warmup");
         add(args, "--runs", "benchmark.runs");
-        add(args, "--scale", "benchmark.scale");
-        add(args, "--minimum-interline-distance", "benchmark.minimumInterlineDistance");
-        add(args, "--thickness", "benchmark.thickness");
-        add(args, "--minimum-baseline-thickness", "benchmark.minimumBaselineThickness");
-        add(args, "--ignore-broken", "benchmark.ignoreBroken");
+        add(args, "--clean-borders", "benchmark.cleanBorders");
+        add(args, "--border-margin", "benchmark.borderMargin");
+        add(args, "--as-single-region", "benchmark.asSingleRegion");
+        add(args, "--interline-clustering-multiplier", "benchmark.interlineClusteringMultiplier");
+        add(args, "--dubious-size-width-multiplier", "benchmark.dubiousSizeWidthMultiplier");
         add(args, "--ignore-xml-errors", "benchmark.ignoreXmlErrors");
         add(args, "--suppress-stderr", "benchmark.suppressStderr");
-        add(args, "--dump-contours", "benchmark.dumpContours");
 
-        RecalculateContoursBenchmark.main(args.toArray(new String[0]));
+        ReadingOrderBenchmark.main(args.toArray(new String[0]));
     }
 
     private static void add(List<String> args, String flag, String property) {

--- a/minions/src/test/java/nl/knaw/huc/di/images/minions/SplitImageBenchmark.java
+++ b/minions/src/test/java/nl/knaw/huc/di/images/minions/SplitImageBenchmark.java
@@ -1,7 +1,8 @@
+package nl.knaw.huc.di.images.minions;
+
 import nl.knaw.huc.di.images.layoutanalyzer.layoutlib.LayoutProc;
 import nl.knaw.huc.di.images.layoutanalyzer.layoutlib.OpenCVWrapper;
 import nl.knaw.huc.di.images.layoutds.models.Page.PcGts;
-import nl.knaw.huc.di.images.layoutds.models.Page.TextLine;
 import nl.knaw.huc.di.images.layoutds.models.Page.TextRegion;
 import nl.knaw.huc.di.images.pagexmlutils.PageUtils;
 import org.opencv.core.Core;
@@ -9,44 +10,54 @@ import org.opencv.core.Mat;
 import org.opencv.imgcodecs.Imgcodecs;
 
 import java.io.BufferedWriter;
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Supplier;
 
-public class RecalculateContoursBenchmark {
+public class SplitImageBenchmark {
     private static final class Config {
-        private Path imageDir = Paths.get("/data/ijsberg/full/train");
-        private Path xmlDir = Paths.get("/data/ijsberg/full/train/page");
-        private Path csv = Paths.get("/tmp/recalculate-contours-benchmark.csv");
-        private String label = "benchmark";
-        private int limit = 20;
-        private int warmup = 1;
-        private int runs = 3;
-        private double scaleDownFactor = 4;
-        private int minimumInterlineDistance = 35;
-        private int thickness = 10;
-        private int minimumBaselineThickness = 1;
-        private boolean ignoreBroken = true;
-        private boolean ignoreXmlErrors = false;
-        private boolean suppressStderr = true;
-        private Path dumpContours = null;
+        Path imageDir = Paths.get("/data/ijsberg/full/train");
+        Path xmlDir = Paths.get("/data/ijsberg/full/train/page");
+        Path outputBase = null;
+        Path csv = Paths.get("/tmp/split-image-benchmark.csv");
+        String label = "benchmark";
+        int limit = 20;
+        int warmup = 1;
+        int runs = 3;
+        int minWidth = 5;
+        int minHeight = 5;
+        int minWidthToHeight = 0;
+        String outputType = "png";
+        int channels = 4;
+        boolean recalculateTextLineContoursFromBaselines = true;
+        int minimumInterlineDistance = 35;
+        int pngCompressionLevel = 1;
+        int minimumBaselineThickness = 1;
+        boolean ignoreXmlErrors = false;
+        boolean suppressStderr = true;
     }
 
     private static final class Pair {
-        private final String stem;
-        private final Path image;
-        private final Path xml;
+        final String stem;
+        final Path image;
+        final Path xml;
 
-        private Pair(String stem, Path image, Path xml) {
+        Pair(String stem, Path image, Path xml) {
             this.stem = stem;
             this.image = image;
             this.xml = xml;
@@ -54,14 +65,14 @@ public class RecalculateContoursBenchmark {
     }
 
     private static final class Measurement {
-        private final String stem;
-        private final int run;
-        private final long elapsedNanos;
-        private final int width;
-        private final int height;
-        private final int lines;
+        final String stem;
+        final int run;
+        final long elapsedNanos;
+        final int width;
+        final int height;
+        final int lines;
 
-        private Measurement(String stem, int run, long elapsedNanos, int width, int height, int lines) {
+        Measurement(String stem, int run, long elapsedNanos, int width, int height, int lines) {
             this.stem = stem;
             this.run = run;
             this.elapsedNanos = elapsedNanos;
@@ -76,100 +87,95 @@ public class RecalculateContoursBenchmark {
         Config config = parseArgs(args);
         System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
 
-        List<Pair> pairs = selectPairs(findPairs(config), config.limit);
-        if (pairs.isEmpty()) {
-            throw new IllegalArgumentException("No image/xml pairs found in " + config.imageDir + " and " + config.xmlDir);
-        }
-
-        if (config.csv.getParent() != null) {
-            Files.createDirectories(config.csv.getParent());
-        }
-
-        List<Measurement> measurements = new ArrayList<>();
-        int failures = 0;
-        BufferedWriter dumpWriter = null;
-        if (config.dumpContours != null) {
-            if (config.dumpContours.getParent() != null) {
-                Files.createDirectories(config.dumpContours.getParent());
-            }
-            dumpWriter = Files.newBufferedWriter(config.dumpContours, StandardCharsets.UTF_8);
-            dumpWriter.write("stem\tlineId\tcontour");
-            dumpWriter.newLine();
-        }
-        try (BufferedWriter writer = Files.newBufferedWriter(config.csv, StandardCharsets.UTF_8)) {
-            writer.write("label,stem,run,elapsed_ms,width,height,lines,status,error");
-            writer.newLine();
-
-            for (int i = 0; i < config.warmup; i++) {
-                failures += executeRun(config, pairs, -1, writer, null, null);
-                System.gc();
+        Path outputBase = config.outputBase != null
+                ? config.outputBase
+                : Files.createTempDirectory("split-image-bench-");
+        try {
+            List<Pair> pairs = selectPairs(findPairs(config), config.limit);
+            if (pairs.isEmpty()) {
+                throw new IllegalArgumentException("No image/xml pairs found in " + config.imageDir);
             }
 
-            for (int run = 1; run <= config.runs; run++) {
-                // Only dump contours during run 1 to keep the dump deterministic
-                // and avoid quadrupling the file size.
-                BufferedWriter dumpForRun = run == 1 ? dumpWriter : null;
-                failures += executeRun(config, pairs, run, writer, measurements, dumpForRun);
-                System.gc();
+            if (config.csv.getParent() != null) {
+                Files.createDirectories(config.csv.getParent());
             }
+
+            List<Measurement> measurements = new ArrayList<>();
+            int failures = 0;
+            try (BufferedWriter writer = Files.newBufferedWriter(config.csv, StandardCharsets.UTF_8)) {
+                writer.write("label,stem,run,elapsed_ms,width,height,lines,status,error");
+                writer.newLine();
+
+                for (int i = 0; i < config.warmup; i++) {
+                    failures += executeRun(config, pairs, -1, writer, null, outputBase);
+                    System.gc();
+                }
+
+                for (int run = 1; run <= config.runs; run++) {
+                    failures += executeRun(config, pairs, run, writer, measurements, outputBase);
+                    System.gc();
+                }
+            }
+
+            List<Double> elapsedMillis = new ArrayList<>();
+            for (Measurement measurement : measurements) {
+                elapsedMillis.add(measurement.elapsedNanos / 1_000_000d);
+            }
+            Collections.sort(elapsedMillis);
+
+            double totalMillis = 0;
+            for (double elapsed : elapsedMillis) {
+                totalMillis += elapsed;
+            }
+
+            System.out.printf(Locale.ROOT,
+                    "BENCHMARK_SUMMARY label=%s pairs=%d runs=%d measurements=%d failures=%d total_ms=%.3f median_ms=%.3f p95_ms=%.3f peak_rss_kb=%d csv=%s%n",
+                    config.label,
+                    pairs.size(),
+                    config.runs,
+                    measurements.size(),
+                    failures,
+                    totalMillis,
+                    percentile(elapsedMillis, 0.50),
+                    percentile(elapsedMillis, 0.95),
+                    peakRssKb(),
+                    config.csv);
         } finally {
-            if (dumpWriter != null) {
-                dumpWriter.close();
+            if (config.outputBase == null) {
+                deleteRecursively(outputBase);
             }
         }
-
-        List<Double> elapsedMillis = new ArrayList<>();
-        for (Measurement measurement : measurements) {
-            elapsedMillis.add(measurement.elapsedNanos / 1_000_000d);
-        }
-        Collections.sort(elapsedMillis);
-
-        double totalMillis = 0;
-        for (double elapsed : elapsedMillis) {
-            totalMillis += elapsed;
-        }
-
-        System.out.printf(Locale.ROOT,
-                "BENCHMARK_SUMMARY label=%s pairs=%d runs=%d measurements=%d failures=%d total_ms=%.3f median_ms=%.3f p95_ms=%.3f peak_rss_kb=%d csv=%s%n",
-                config.label,
-                pairs.size(),
-                config.runs,
-                measurements.size(),
-                failures,
-                totalMillis,
-                percentile(elapsedMillis, 0.50),
-                percentile(elapsedMillis, 0.95),
-                peakRssKb(),
-                config.csv);
     }
 
     private static int executeRun(Config config, List<Pair> pairs, int run, BufferedWriter writer,
-                                  List<Measurement> measurements, BufferedWriter dumpWriter) throws IOException {
+                                  List<Measurement> measurements, Path outputBase) throws IOException {
         int failures = 0;
         for (Pair pair : pairs) {
-            Mat image = null;
+            Path runOutput = outputBase.resolve(pair.stem + "-r" + Math.max(run, 0));
+            Mat probeImage = null;
             try {
-                String xml = Files.readString(pair.xml);
-                PcGts page = PageUtils.readPageFromString(xml, config.ignoreXmlErrors);
-                if (page == null) {
-                    throw new IllegalStateException("PAGE parse returned null");
-                }
-
-                image = OpenCVWrapper.imread(pair.image.toString(), Imgcodecs.IMREAD_COLOR);
-                if (image.empty()) {
+                probeImage = OpenCVWrapper.imread(pair.image.toString(), Imgcodecs.IMREAD_COLOR);
+                if (probeImage.empty()) {
                     throw new IllegalStateException("Image could not be read");
                 }
-                int lines = countLines(page);
+                int width = probeImage.width();
+                int height = probeImage.height();
 
-                long elapsed = measureRecalculate(config, pair, image, page);
+                String xml = Files.readString(pair.xml);
+                PcGts probePage = PageUtils.readPageFromString(xml, config.ignoreXmlErrors);
+                if (probePage == null) {
+                    throw new IllegalStateException("PAGE parse returned null");
+                }
+                int lines = countLines(probePage);
+
+                Files.createDirectories(runOutput);
+
+                long elapsed = measureSplit(config, pair, runOutput);
 
                 if (run > 0) {
-                    Measurement measurement = new Measurement(pair.stem, run, elapsed, image.width(), image.height(), lines);
+                    Measurement measurement = new Measurement(pair.stem, run, elapsed, width, height, lines);
                     measurements.add(measurement);
                     writeCsv(writer, config.label, measurement, "ok", "");
-                    if (dumpWriter != null) {
-                        dumpContours(dumpWriter, pair.stem, page);
-                    }
                 }
             } catch (Exception exception) {
                 failures++;
@@ -184,15 +190,18 @@ public class RecalculateContoursBenchmark {
                     writer.newLine();
                 }
             } finally {
-                if (image != null && image.dataAddr() != 0) {
-                    image = OpenCVWrapper.release(image);
+                if (probeImage != null && probeImage.dataAddr() != 0) {
+                    probeImage = OpenCVWrapper.release(probeImage);
+                }
+                if (config.outputBase == null) {
+                    deleteRecursively(runOutput);
                 }
             }
         }
         return failures;
     }
 
-    private static long measureRecalculate(Config config, Pair pair, Mat image, PcGts page) {
+    private static long measureSplit(Config config, Pair pair, Path runOutput) {
         PrintStream originalErr = System.err;
         PrintStream mutedErr = null;
         if (config.suppressStderr) {
@@ -200,17 +209,55 @@ public class RecalculateContoursBenchmark {
             System.setErr(mutedErr);
         }
 
+        Supplier<Mat> imageSupplier = () -> OpenCVWrapper.imread(pair.image.toString(), Imgcodecs.IMREAD_COLOR);
+        Supplier<PcGts> pageSupplier = () -> {
+            try {
+                String xml = Files.readString(pair.xml);
+                return PageUtils.readPageFromString(xml, config.ignoreXmlErrors);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+
+        MinionCutFromImageBasedOnPageXMLNew minion = new MinionCutFromImageBasedOnPageXMLNew(
+                pair.stem,
+                imageSupplier,
+                pageSupplier,
+                runOutput.toString(),
+                pair.image.getFileName().toString(),
+                /* overwriteExistingPage */ false,
+                config.minWidth,
+                config.minHeight,
+                config.minWidthToHeight,
+                config.outputType,
+                config.channels,
+                /* writeTextContents */ false,
+                /* rescaleHeight */ null,
+                /* outputConfidenceFile */ false,
+                /* outputBoxFile */ true,
+                /* outputTxtFile */ true,
+                config.recalculateTextLineContoursFromBaselines,
+                /* fixedXHeight */ null,
+                LayoutProc.MINIMUM_XHEIGHT,
+                /* useDiforNames */ false,
+                /* writeDoneFiles */ false,
+                /* ignoreDoneFiles */ true,
+                /* errorLog */ error -> {},
+                /* includeTextStyles */ false,
+                /* useTags */ false,
+                /* skipUnclear */ false,
+                /* minimumConfidence */ null,
+                /* maximumConfidence */ null,
+                config.minimumInterlineDistance,
+                config.pngCompressionLevel,
+                Optional.empty(),
+                /* tmpdir */ null,
+                config.minimumBaselineThickness,
+                /* coffeeStains */ 0);
+
         long start = System.nanoTime();
         try {
-            LayoutProc.recalculateTextLineContoursFromBaselines(
-                    pair.stem,
-                    image,
-                    page,
-                    config.scaleDownFactor,
-                    config.minimumInterlineDistance,
-                    config.thickness,
-                    config.minimumBaselineThickness,
-                    config.ignoreBroken);
+            minion.run();
             return System.nanoTime() - start;
         } finally {
             if (mutedErr != null) {
@@ -262,33 +309,12 @@ public class RecalculateContoursBenchmark {
         if (limit <= 0 || limit >= pairs.size()) {
             return pairs;
         }
-
         List<Pair> selected = new ArrayList<>(limit);
         double step = (double) pairs.size() / (double) limit;
         for (int i = 0; i < limit; i++) {
             selected.add(pairs.get((int) Math.floor(i * step)));
         }
         return selected;
-    }
-
-    private static void dumpContours(BufferedWriter writer, String stem, PcGts page) throws IOException {
-        // Stable, sortable per-line dump for equivalence checking across optimization
-        // runs. Format: <stem>\t<lineId>\t<x1,y1 x2,y2 ...>. Lines emitted in
-        // (region order, line order) — same as the in-memory page traversal.
-        for (TextRegion textRegion : page.getPage().getTextRegions()) {
-            for (TextLine textLine : textRegion.getTextLines()) {
-                String coords = "";
-                if (textLine.getCoords() != null && textLine.getCoords().getPoints() != null) {
-                    coords = textLine.getCoords().getPoints();
-                }
-                writer.write(stem);
-                writer.write('\t');
-                writer.write(textLine.getId() == null ? "" : textLine.getId());
-                writer.write('\t');
-                writer.write(coords);
-                writer.newLine();
-            }
-        }
     }
 
     private static int countLines(PcGts page) {
@@ -338,6 +364,28 @@ public class RecalculateContoursBenchmark {
         return "\"" + value.replace("\"", "\"\"") + "\"";
     }
 
+    private static void deleteRecursively(Path path) {
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+        try {
+            Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.deleteIfExists(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.deleteIfExists(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException ignored) {
+        }
+    }
+
     private static Config parseArgs(String[] args) {
         Config config = new Config();
         for (int i = 0; i < args.length; i++) {
@@ -348,6 +396,9 @@ public class RecalculateContoursBenchmark {
                     break;
                 case "--xml-dir":
                     config.xmlDir = Paths.get(value(args, ++i, arg));
+                    break;
+                case "--output-base":
+                    config.outputBase = Paths.get(value(args, ++i, arg));
                     break;
                 case "--csv":
                     config.csv = Paths.get(value(args, ++i, arg));
@@ -364,29 +415,38 @@ public class RecalculateContoursBenchmark {
                 case "--runs":
                     config.runs = Integer.parseInt(value(args, ++i, arg));
                     break;
-                case "--scale":
-                    config.scaleDownFactor = Double.parseDouble(value(args, ++i, arg));
+                case "--min-width":
+                    config.minWidth = Integer.parseInt(value(args, ++i, arg));
+                    break;
+                case "--min-height":
+                    config.minHeight = Integer.parseInt(value(args, ++i, arg));
+                    break;
+                case "--min-width-to-height":
+                    config.minWidthToHeight = Integer.parseInt(value(args, ++i, arg));
+                    break;
+                case "--output-type":
+                    config.outputType = value(args, ++i, arg);
+                    break;
+                case "--channels":
+                    config.channels = Integer.parseInt(value(args, ++i, arg));
+                    break;
+                case "--recalculate-contours":
+                    config.recalculateTextLineContoursFromBaselines = Boolean.parseBoolean(value(args, ++i, arg));
                     break;
                 case "--minimum-interline-distance":
                     config.minimumInterlineDistance = Integer.parseInt(value(args, ++i, arg));
                     break;
-                case "--thickness":
-                    config.thickness = Integer.parseInt(value(args, ++i, arg));
+                case "--png-compression-level":
+                    config.pngCompressionLevel = Integer.parseInt(value(args, ++i, arg));
                     break;
                 case "--minimum-baseline-thickness":
                     config.minimumBaselineThickness = Integer.parseInt(value(args, ++i, arg));
-                    break;
-                case "--ignore-broken":
-                    config.ignoreBroken = Boolean.parseBoolean(value(args, ++i, arg));
                     break;
                 case "--ignore-xml-errors":
                     config.ignoreXmlErrors = Boolean.parseBoolean(value(args, ++i, arg));
                     break;
                 case "--suppress-stderr":
                     config.suppressStderr = Boolean.parseBoolean(value(args, ++i, arg));
-                    break;
-                case "--dump-contours":
-                    config.dumpContours = Paths.get(value(args, ++i, arg));
                     break;
                 default:
                     throw new IllegalArgumentException("Unknown argument: " + arg);

--- a/minions/src/test/java/nl/knaw/huc/di/images/minions/SplitImageBenchmarkTest.java
+++ b/minions/src/test/java/nl/knaw/huc/di/images/minions/SplitImageBenchmarkTest.java
@@ -1,10 +1,12 @@
+package nl.knaw.huc.di.images.minions;
+
 import org.junit.Assume;
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.List;
 
-public class RecalculateContoursBenchmarkTest {
+public class SplitImageBenchmarkTest {
     @Test
     public void runBenchmark() throws Exception {
         Assume.assumeTrue(Boolean.getBoolean("benchmark.enabled"));
@@ -12,21 +14,25 @@ public class RecalculateContoursBenchmarkTest {
         List<String> args = new ArrayList<>();
         add(args, "--image-dir", "benchmark.imageDir");
         add(args, "--xml-dir", "benchmark.xmlDir");
+        add(args, "--output-base", "benchmark.outputBase");
         add(args, "--csv", "benchmark.csv");
         add(args, "--label", "benchmark.label");
         add(args, "--limit", "benchmark.limit");
         add(args, "--warmup", "benchmark.warmup");
         add(args, "--runs", "benchmark.runs");
-        add(args, "--scale", "benchmark.scale");
+        add(args, "--min-width", "benchmark.minWidth");
+        add(args, "--min-height", "benchmark.minHeight");
+        add(args, "--min-width-to-height", "benchmark.minWidthToHeight");
+        add(args, "--output-type", "benchmark.outputType");
+        add(args, "--channels", "benchmark.channels");
+        add(args, "--recalculate-contours", "benchmark.recalculateContours");
         add(args, "--minimum-interline-distance", "benchmark.minimumInterlineDistance");
-        add(args, "--thickness", "benchmark.thickness");
+        add(args, "--png-compression-level", "benchmark.pngCompressionLevel");
         add(args, "--minimum-baseline-thickness", "benchmark.minimumBaselineThickness");
-        add(args, "--ignore-broken", "benchmark.ignoreBroken");
         add(args, "--ignore-xml-errors", "benchmark.ignoreXmlErrors");
         add(args, "--suppress-stderr", "benchmark.suppressStderr");
-        add(args, "--dump-contours", "benchmark.dumpContours");
 
-        RecalculateContoursBenchmark.main(args.toArray(new String[0]));
+        SplitImageBenchmark.main(args.toArray(new String[0]));
     }
 
     private static void add(List<String> args, String flag, String property) {

--- a/minions/src/test/java/nl/knaw/huc/di/images/minions/SplitImageRecalculateCorrectnessTest.java
+++ b/minions/src/test/java/nl/knaw/huc/di/images/minions/SplitImageRecalculateCorrectnessTest.java
@@ -1,0 +1,226 @@
+package nl.knaw.huc.di.images.minions;
+
+import nl.knaw.huc.di.images.layoutanalyzer.layoutlib.LayoutProc;
+import nl.knaw.huc.di.images.layoutanalyzer.layoutlib.OpenCVWrapper;
+import nl.knaw.huc.di.images.layoutds.models.Page.PcGts;
+import nl.knaw.huc.di.images.pagexmlutils.PageUtils;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.opencv.core.Core;
+import org.opencv.core.Mat;
+import org.opencv.imgcodecs.Imgcodecs;
+
+import java.io.IOException;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+
+/**
+ * Verifies that skipping contour recalculation in split-image produces bit-for-bit
+ * identical line-strip PNGs when the PAGE XML already contains fresh seam-traced contours
+ * (i.e. extract-baselines already ran with recalculate=true, as the web service does).
+ *
+ * Gated on -Dbenchmark.enabled=true so it does not run in normal CI builds.
+ * Run via: mvn -pl minions -am -DargLine=-Djava.library.path=/usr/local/share/java/opencv4
+ *              -Dtest=SplitImageRecalculateCorrectnessTest -Dbenchmark.enabled=true
+ *              -DfailIfNoTests=false test
+ */
+public class SplitImageRecalculateCorrectnessTest {
+
+    private static final String IMAGE_DIR = System.getProperty("correctness.imageDir",
+            "/data/ijsberg/full/train");
+    private static final String XML_DIR = System.getProperty("correctness.xmlDir",
+            "/data/ijsberg/full/train/page");
+    private static final int LIMIT = Integer.getInteger("correctness.limit", 3);
+
+    @Test
+    public void recalculateSkipProducesIdenticalOutputs() throws Exception {
+        Assume.assumeTrue("Set -Dbenchmark.enabled=true to run", Boolean.getBoolean("benchmark.enabled"));
+        System.loadLibrary(Core.NATIVE_LIBRARY_NAME);
+
+        List<String> stems = selectStems(LIMIT);
+        Assert.assertFalse("No paired image/xml found in " + IMAGE_DIR, stems.isEmpty());
+
+        int totalCompared = 0;
+        int totalDifferent = 0;
+        List<String> differingFiles = new ArrayList<>();
+
+        for (String stem : stems) {
+            Path imagePath = Paths.get(IMAGE_DIR, stem + ".jpg");
+            Path xmlPath = Paths.get(XML_DIR, stem + ".xml");
+
+            String originalXml = Files.readString(xmlPath);
+            String namespace = PageUtils.NAMESPACE2013;
+
+            // Step 1: recalculate contours (simulates what extract-baselines does in the web service)
+            Mat image = OpenCVWrapper.imread(imagePath.toString(), Imgcodecs.IMREAD_COLOR);
+            try {
+                PcGts page = PageUtils.readPageFromString(originalXml);
+                LayoutProc.recalculateTextLineContoursFromBaselines(
+                        stem, image, page,
+                        MinionCutFromImageBasedOnPageXMLNew.SHRINK_FACTOR,
+                        MinionCutFromImageBasedOnPageXMLNew.DEFAULT_MINIMUM_INTERLINE_DISTANCE,
+                        /* thickness */ 10,
+                        /* minimumBaselineThickness */ 1,
+                        /* ignoreBroken */ true);
+                String freshXml = PageUtils.convertPcGtsToString(page, namespace);
+
+                // Step 2a: run split-image with recalculate=true (recomputes from scratch)
+                Path outTrue = Files.createTempDirectory("split-true-");
+                runSplit(stem, imagePath, freshXml, true, outTrue);
+
+                // Step 2b: run split-image with recalculate=true AGAIN — determinism check
+                Path outTrue2 = Files.createTempDirectory("split-true2-");
+                runSplit(stem, imagePath, freshXml, true, outTrue2);
+
+                Map<String, Path> trueFiles2a = collectPngs(outTrue);
+                Map<String, Path> trueFiles2b = collectPngs(outTrue2);
+                int deterministicDiff = 0;
+                for (Map.Entry<String, Path> e : trueFiles2a.entrySet()) {
+                    Path other = trueFiles2b.get(e.getKey());
+                    if (other != null && !Arrays.equals(Files.readAllBytes(e.getValue()), Files.readAllBytes(other))) {
+                        deterministicDiff++;
+                    }
+                }
+                System.out.printf("  %s: determinism check (recalc=true twice): %d/%d differ%n",
+                        stem, deterministicDiff, trueFiles2a.size());
+                deleteRecursively(outTrue2);
+
+                // Step 3: run split-image with recalculate=false (uses the already-fresh contours)
+                Path outFalse = Files.createTempDirectory("split-false-");
+                runSplit(stem, imagePath, freshXml, false, outFalse);
+
+                // Step 4: compare outputs
+                Map<String, Path> trueFiles = collectPngs(outTrue);
+                Map<String, Path> falseFiles = collectPngs(outFalse);
+
+                for (Map.Entry<String, Path> entry : trueFiles.entrySet()) {
+                    String name = entry.getKey();
+                    totalCompared++;
+                    if (!falseFiles.containsKey(name)) {
+                        totalDifferent++;
+                        differingFiles.add(stem + "/" + name + " (missing in no-recalc)");
+                        continue;
+                    }
+                    byte[] trueBytes = Files.readAllBytes(entry.getValue());
+                    byte[] falseBytes = Files.readAllBytes(falseFiles.get(name));
+                    if (!Arrays.equals(trueBytes, falseBytes)) {
+                        totalDifferent++;
+                        Mat tImg = OpenCVWrapper.imread(entry.getValue().toString(), Imgcodecs.IMREAD_UNCHANGED);
+                        Mat fImg = OpenCVWrapper.imread(falseFiles.get(name).toString(), Imgcodecs.IMREAD_UNCHANGED);
+                        String sizeNote = tImg.width() + "x" + tImg.height() + " vs " + fImg.width() + "x" + fImg.height();
+                        OpenCVWrapper.release(tImg);
+                        OpenCVWrapper.release(fImg);
+                        differingFiles.add(stem + "/" + name + " [" + sizeNote + "]");
+                    }
+                }
+                for (String name : falseFiles.keySet()) {
+                    if (!trueFiles.containsKey(name)) {
+                        totalCompared++;
+                        totalDifferent++;
+                        differingFiles.add(stem + "/" + name + " (only in no-recalc)");
+                    }
+                }
+
+                deleteRecursively(outTrue);
+                deleteRecursively(outFalse);
+            } finally {
+                OpenCVWrapper.release(image);
+            }
+        }
+
+        System.out.printf("Correctness check: %d pages, %d PNGs compared, %d different%n",
+                stems.size(), totalCompared, totalDifferent);
+        if (!differingFiles.isEmpty()) {
+            System.out.println("Differing files (first 20):");
+            differingFiles.stream().limit(20).forEach(f -> System.out.println("  " + f));
+        }
+
+        Assert.assertEquals(
+                totalDifferent + " of " + totalCompared + " PNGs differ between recalculate=true and recalculate=false on fresh XML",
+                0, totalDifferent);
+    }
+
+    private static void runSplit(String stem, Path imagePath, String xmlString,
+                                  boolean recalculate, Path outputDir) throws IOException {
+        MinionCutFromImageBasedOnPageXMLNew minion = new MinionCutFromImageBasedOnPageXMLNew(
+                stem,
+                () -> OpenCVWrapper.imread(imagePath.toString(), Imgcodecs.IMREAD_COLOR),
+                () -> PageUtils.readPageFromString(xmlString),
+                outputDir.toString(),
+                imagePath.getFileName().toString(),
+                /* overwriteExistingPage */ false,
+                /* minWidth */ 5,
+                /* minHeight */ 5,
+                /* minWidthToHeight */ 0,
+                /* outputType */ "png",
+                /* channels */ 4,
+                /* writeTextContents */ false,
+                /* rescaleHeight */ null,
+                /* outputConfidenceFile */ false,
+                /* outputBoxFile */ false,
+                /* outputTxtFile */ false,
+                recalculate,
+                /* fixedXHeight */ null,
+                LayoutProc.MINIMUM_XHEIGHT,
+                /* useDiforNames */ false,
+                /* writeDoneFiles */ false,
+                /* ignoreDoneFiles */ true,
+                /* errorLog */ error -> {},
+                /* includeTextStyles */ false,
+                /* useTags */ false,
+                /* skipUnclear */ false,
+                /* minimumConfidence */ null,
+                /* maximumConfidence */ null,
+                MinionCutFromImageBasedOnPageXMLNew.DEFAULT_MINIMUM_INTERLINE_DISTANCE,
+                /* pngCompressionLevel */ 1,
+                Optional.empty(),
+                /* tmpdir */ null,
+                /* minimumBaselineThickness */ 1,
+                /* coffeeStains */ 0);
+        minion.run();
+    }
+
+    private static Map<String, Path> collectPngs(Path dir) throws IOException {
+        Map<String, Path> result = new TreeMap<>();
+        if (!Files.exists(dir)) return result;
+        try (var stream = Files.walk(dir)) {
+            stream.filter(p -> p.toString().endsWith(".png"))
+                  .forEach(p -> result.put(dir.relativize(p).toString(), p));
+        }
+        return result;
+    }
+
+    private static List<String> selectStems(int limit) throws IOException {
+        Path imageDir = Paths.get(IMAGE_DIR);
+        Path xmlDir = Paths.get(XML_DIR);
+        List<String> paired = new ArrayList<>();
+        try (var stream = Files.list(imageDir)) {
+            stream.filter(p -> p.toString().endsWith(".jpg"))
+                  .map(p -> p.getFileName().toString())
+                  .map(n -> n.substring(0, n.length() - 4))
+                  .filter(stem -> Files.exists(xmlDir.resolve(stem + ".xml")))
+                  .sorted()
+                  .forEach(paired::add);
+        }
+        if (paired.isEmpty() || limit >= paired.size()) return paired;
+        List<String> selected = new ArrayList<>();
+        for (int i = 0; i < limit; i++) {
+            selected.add(paired.get((int) Math.round((double) i * (paired.size() - 1) / (limit - 1))));
+        }
+        return selected;
+    }
+
+    private static void deleteRecursively(Path dir) throws IOException {
+        if (!Files.exists(dir)) return;
+        Files.walkFileTree(dir, new SimpleFileVisitor<>() {
+            @Override public FileVisitResult visitFile(Path f, BasicFileAttributes a) throws IOException {
+                Files.delete(f); return FileVisitResult.CONTINUE;
+            }
+            @Override public FileVisitResult postVisitDirectory(Path d, IOException e) throws IOException {
+                Files.delete(d); return FileVisitResult.CONTINUE;
+            }
+        });
+    }
+}

--- a/pagexmlutils/src/main/resources/transformpage.xslt
+++ b/pagexmlutils/src/main/resources/transformpage.xslt
@@ -24,8 +24,6 @@
     <xsl:template match="page:Page/@textLineOrder"/>
     <xsl:template match="page:TextRegion/@textLineOrder"/>
 
-    <xsl:template match="page:TextStyle/@xHeight"/>
-
     <xsl:template match="page:TextEquiv/@dataType"/>
 
     <xsl:template match="page:TextEquiv/@dataTypeDetails"/>


### PR DESCRIPTION
# Performance PR Summary

Branch: `perf-improvements`

Base used for recorded main baselines: `dfbfcdd` (`main`)

Date: 2026-05-20

This branch adds repeatable benchmark harnesses, applies measured performance
improvements to the layout-analysis hot paths, adds a fused extract-and-cut
endpoint, and fixes the `minions` JUnit setup so existing Jupiter tests run.

Raw benchmark result bundles are not included in this PR. The tables below are
from local persisted runs on the deterministic 20-page sample.

## Results

Benchmark setup:

- Dataset: The training set of the IJsberg dataset
- `limit=20`, `warmup=1`, `runs=3`
- `60` measurements per benchmark
- All listed benchmark runs had `failures=0`

### Main Baseline vs Optimized

| Benchmark | Main total | Optimized total | Total change | Main median | Optimized median | P95 change | RSS change |
|---|---:|---:|---:|---:|---:|---:|---:|
| recalculate-contours | 76,843.569 ms | 23,080.227 ms | -69.96% / 3.33x | 1,247.474 ms | 371.736 ms | -70.17% | -53.87% |
| split-image | 154,481.004 ms | 106,924.485 ms | -30.78% / 1.44x | 2,535.050 ms | 1,731.349 ms | -32.73% | -31.90% |
| split-words | 994.633 ms | 121.486 ms | -87.79% / 8.19x | 15.331 ms | 1.782 ms | -88.96% | +15.71% |
| reading-order | 2,821.976 ms | 1,986.172 ms | -29.62% / 1.42x | 20.943 ms | 12.147 ms | -33.26% | -25.50% |
| merge | 384.438 ms | 305.956 ms | -20.41% / 1.26x | 6.033 ms | 4.132 ms | -15.18% | -2.76% |

### Final Low-Hanging Pass

After the larger contour/cut work, a final pass targeted split-words,
reading-order, and merge.

| Benchmark | Pre total | Post total | Total change | Median change | P95 change |
|---|---:|---:|---:|---:|---:|
| split-words | 756.145 ms | 121.486 ms | -83.93% / 6.22x | -84.35% | -85.63% |
| reading-order | 2,384.212 ms | 1,986.172 ms | -16.69% / 1.20x | -15.45% | -23.64% |
| merge | 320.811 ms | 305.956 ms | -4.63% | -3.28% | +2.23% |

Interpretation: split-words and reading-order were clear wins. Merge is mostly
speed-neutral within the branch; the cleanup is small and low risk.

## What Changed

### Benchmark Harnesses

Added JUnit-backed benchmark harnesses for:

- `LayoutProc.recalculateTextLineContoursFromBaselines(...)`
- `MinionCutFromImageBasedOnPageXMLNew.run()`
- `LayoutProc.splitLinesIntoWords(page)`
- `MinionRecalculateReadingOrderNew.runPage(...)`
- `MinionLoghiHTRMergePageXML.run()`

The harnesses record CSV rows, summary metrics, failure counts, and peak RSS.

### Contour Recalculation

Optimized the seam path in `LayoutProc`:

- moved large seam/energy Mats to `CV_32F` where appropriate
- released temporary Mats earlier
- cached parsed baseline geometry
- replaced per-pixel JNI `Mat.get`/`Mat.put` in `calcSeamImage` with bulk
  `Mat.get`/`Mat.put` and Java-array DP
- added a finite no-go seam penalty to avoid `Infinity`/`NaN` in `CV_32F`

This produced the biggest CPU and memory improvement.

### Cut Images

Optimized `MinionCutFromImageBasedOnPageXMLNew`:

- avoided a full-image clone when `coffeeStains == 0`
- reused PNG compression parameters per page
- avoided cloning generated line-strip Mats
- removed redundant per-line tmpfile-and-move writes

The `cut-from-image` API now defaults
`recalculate_text_line_contours_from_baselines` to `false`; callers can still
enable it explicitly.

### Split Words, Reading Order, Merge

Split-words now avoids regex splitting and repeated baseline-length scans in the
hot loop.

Reading-order now caches per-line geometry and uses identity sets in clustering.
The algorithm is still quadratic, but cheaper per comparison.

Merge now precompiles the HTR marker regex and reuses per-line lookup keys.

### Extract And Cut Endpoint

Added `POST /extract-and-cut`, which runs extract-baselines and cut-from-image
in one scheduled job. It passes the updated PAGE object in memory, avoiding an
XML disk round-trip and duplicate contour recalculation in the common workflow.

### JUnit Setup

Fixed `minions` JUnit execution:

- added `maven-surefire-plugin` `3.2.5`
- added `junit-vintage-engine` for existing JUnit 4 wrappers
- fixed exposed bad fixtures in `BaselinesMapperTest` and
  `MinionFixPageXMLTest`

On `main`, the Jupiter tests existed but old Surefire reported `Tests run: 0`
for selected Jupiter test classes.

## Verification

- `LayoutProcTest`: `37` tests passed.
- `mvn -pl minions -am -DargLine=-Djava.library.path=/usr/local/share/java/opencv4 -DfailIfNoTests=false test`: passed.
- `minions`: `42` tests, `0` failures, `0` errors, `4` skipped benchmark/correctness wrappers.
- Benchmark harnesses completed with `failures=0`.
- Paired output counter checks for split-words, reading-order, and merge:
  `60` paired rows, `diffs=0`.
- `git diff --check` was clean after the code changes.

## Notes

What worked best:

- bulk Mat access in `calcSeamImage`
- keeping seam costs finite in `CV_32F`
- avoiding redundant Mat clones and per-line file moves
- incremental baseline-length tracking in split-words
- cached text-line geometry in reading-order

Deferred or reverted:

- full bulk-read in `findSeam`: helped recalculate-contours alone but regressed
  split-image due to extra data transfer and allocation churn
- skipping seam-image upscale: contour shapes diverged too much
- reading-order spatial indexing: possible future work, but not worth the
  correctness risk for the measured runtimes
- within-page cut parallelism: deferred because production already parallelizes
  across pages